### PR TITLE
Improvements to Bordered Texture Atlas

### DIFF
--- a/src/bordered_texture_atlas.cpp
+++ b/src/bordered_texture_atlas.cpp
@@ -90,7 +90,7 @@ int bordered_texture_atlas::compareCanonicalTextureSizes(const void *parameter1,
 void bordered_texture_atlas::layOutTextures()
 {
     // First step: Sort the canonical textures by size.
-    unsigned long *sorted_indices = (unsigned long *) malloc(sizeof(unsigned long) * number_canonical_object_textures);
+    unsigned long *sorted_indices = new unsigned long[number_canonical_object_textures];
     for (unsigned long i = 0; i < number_canonical_object_textures; i++)
         sorted_indices[i] = i;
 
@@ -108,7 +108,7 @@ void bordered_texture_atlas::layOutTextures()
         struct canonical_object_texture &canonical = canonical_object_textures[sorted_indices[texture]];
 
         // Try to find space in an existing page.
-        int found_place = 0;
+        bool found_place = 0;
         for (unsigned long page = 0; page < number_result_pages; page++)
         {
             found_place = BSPTree2D_FindSpaceFor(result_pages[page],
@@ -149,22 +149,18 @@ void bordered_texture_atlas::layOutTextures()
     }
 
     // Fix up heights if necessary
-    //if (!supports_npot)
+    for (unsigned page = 0; page < number_result_pages; page++)
     {
-        for (unsigned page = 0; page < number_result_pages; page++)
-        {
-            result_page_height[page] = NextPowerOf2(result_page_height[page]);
-        }
+        result_page_height[page] = NextPowerOf2(result_page_height[page]);
     }
 
     // Cleanup
-    free(sorted_indices);
+    delete [] sorted_indices;
     for (unsigned long i = 0; i < number_result_pages; i++)
         BSPTree2D_Destroy(result_pages[i]);
     free(result_pages);
 }
 
-// Leave everything at 0, except border width. Calls to realloc will fill it up.
 bordered_texture_atlas::bordered_texture_atlas(int border,
                                                size_t page_count,
                                                const tr4_textile32_t *pages,
@@ -203,6 +199,7 @@ original_pages(pages)
 bordered_texture_atlas::~bordered_texture_atlas()
 {
     delete [] file_object_textures;
+    delete [] canonical_textures_for_sprite_textures;
     delete [] canonical_object_textures;
     free(result_page_height);
 }

--- a/src/bordered_texture_atlas.h
+++ b/src/bordered_texture_atlas.h
@@ -32,114 +32,175 @@
 #include "vt/tr_types.h"
 #include "polygon.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-/*!
- * @struct bordered_texture_atlas_s
- * @abstract The bordered texture atlas.
- * @discussion The contents of this struct are private and subject to change. Do
- * not put an instance of it on the stack; only create it through @see BorderedTextureAtlas_Create.
- */
-typedef struct bordered_texture_atlas_s *bordered_texture_atlas_p;
-
-/*!
- * Create a new Bordered texture atlas with the specified border width. This
- * width cannot be changed later.
- * @param border The border width around each texture.
- */
-bordered_texture_atlas_p BorderedTextureAtlas_Create(int border);
+class bordered_texture_atlas
+{
+    /*!
+     * @abstract Identifies a corner.
+     * @discussion This is used for mapping a corner in a file object texture to the corresponding corner in the canonical object texture.
+     */
+    enum corner_location
+    {
+        TOP_LEFT,
+        TOP_RIGHT,
+        BOTTOM_LEFT,
+        BOTTOM_RIGHT
+    };
     
-/*!
- * Destroy all contents of a bordered texture atlas. Using the atlas afterwards
- * is an error and undefined. If textures have been uploaded, then the OpenGL
- * texture objects will not be destroyed.
- */
-void BorderedTextureAtlas_Destroy(bordered_texture_atlas_p atlas);
+    /*!
+     * An internal representation of a file texture. Note that this only stores a reference to the canonical texture and how the corners of the canonical texture map to this.
+     */
+    struct file_object_texture
+    {
+        unsigned long canonical_texture_index;
+        enum corner_location corner_locations[4];
+    };
+    
+    /*!
+     * The canonical texture. In TR, a lot of textures can refer to the same rectangle of pixels, only in different winding orders. It is not practical to treat these as different textures, so they are all mapped to one canonical object texture. This structure consists of two parts: Describing the original location, and describing the new final location. The latter is only valid after the data in the texture atlas has been laid out.
+     */
+    struct canonical_object_texture
+    {
+        // The unadjusted size
+        uint8_t width;
+        uint8_t height;
+        
+        // Original origin
+        uint16_t original_page;
+        uint8_t original_x;
+        uint8_t original_y;
+        
+        // New origin
+        unsigned long new_page;
+        unsigned new_x_with_border; // Where the adjusted data starts. The start of the actual data is this plus the atlas's border size.
+        unsigned new_y_with_border; // See above.
+    };
+    
+    // How much border to add.
+    int border_width;
+    
+    // Store whether the data has been laid out. Adding more object textures after that is illegal.
+    bool data_has_been_laid_out = false;
+    
+    // Whether non-power-of-two textures are supported.
+    //int supports_npot;
+    
+    // Result pages
+    // Note: No capacity here, this is handled internally by the layout method. Also, all result pages have the same width, which will always be less than or equal to the height.
+    unsigned long number_result_pages = 0;
+    unsigned result_page_width = 0;
+    unsigned *result_page_height = nullptr;
+    
+    // Original data
+    unsigned long number_original_pages = 0;
+    unsigned long capacity_original_pages = 0;
+    void **original_pages = nullptr;
+    
+    // Object textures in the file.
+    unsigned long number_file_object_textures = 0;
+    unsigned long capacity_file_object_textures = 0;
+    struct file_object_texture *file_object_textures = nullptr;
+    
+    // Sprite texture in the file.
+    // Note: No data is saved for them, they get mapped directly to canonical textures.
+    unsigned long number_sprite_textures = 0;
+    unsigned long capacity_sprite_textures = 0;
+    unsigned long *canonical_textures_for_sprite_textures = nullptr;
+    
+    // Canonical object textures
+    unsigned long number_canonical_object_textures = 0;
+    unsigned long capacity_canonical_object_textures = 0;
+    struct canonical_object_texture *canonical_object_textures = nullptr;
+    
+    /*! Lays out the texture data and switches the atlas to laid out mode. */
+    void layOutTextures();
+    
+    /*! For sorting: Compares two different textures and sorts them by size. */
+    static int compareCanonicalTextureSizes(const void *parameter1, const void *parameter2);
+    
+public:
+    /*!
+     * Create a new Bordered texture atlas with the specified border width. This
+     * width cannot be changed later.
+     * @param border The border width around each texture.
+     */
+    bordered_texture_atlas(int border);
+    
+    /*!
+     * Destroy all contents of a bordered texture atlas. Using the atlas afterwards
+     * is an error and undefined. If textures have been uploaded, then the OpenGL
+     * texture objects will not be destroyed.
+     */
+    ~bordered_texture_atlas();
+    
+    /*!
+     * Add a 32-bit 256x256 texture page. The atlas will use it to get the texture
+     * data later. It does not copy the data, so this pointer must remain valid at
+     * least until @see BorderedTextureAtlas_CreateTextures gets called.
+     * @param trpage The data. Must have a size of 256x256x4 = 256 kB, and be stored in RGBA format.
+     */
+    void addPage(void *trpage);
+    
+    /*!
+     * Add the contents of a Tomb Raider object texture. An object texture is how
+     * Tomb Raider stores its texture coordinates. As simplification, this method
+     * assumes/requires that this region is always an axis aligned rectangle, which
+     * is true for all known levels. Only textures that got added through this
+     * method will appear in the final result. They must be added in the original
+     * order for @see BorderedTextureAtlas_GetCoordinates to work as expected.
+     * @param texture The object texture.
+     */
+    void addObjectTexture(const tr4_object_texture_t &texture);
+    
+    /*!
+     * Same as above, but for sprite textures.
+     */
+    void addSpriteTexture(const tr_sprite_texture_t &texture);
+    
+    /*!
+     * Returns the texture coordinates of the specified texture. This must only be
+     * called after all pages and object texture coordinates have been added.
+     * Otherwise the size calculation code won't work.
+     * @param texture The texture.
+     * @param numCoordinates The number of coordinates you want. Typically 3 (for a triangle) or 4 (for a rectangle). Must be smaller than 5.
+     * @param reverse Whether to reverse the order of texture coordinates on output.
+     * @param outPage The page in the resulting texture atlas.
+     * @param coordiantes The coordinates of the specified texture.
+     * you don't think you'll need them all.
+     */
+    void getCoordinates(unsigned long texture,
+                        bool reverse,
+                        polygon_p poly,
+                        signed shift = 0,
+                        bool split = false);
+    
+    /*!
+     * Same as above, but for sprite textures. This always returns four coordinates (eight float values), in the order top right, top left, bottom left, bottom right.
+     */
+    void getSpriteCoordinates(unsigned long sprite_texture,
+                              uint32_t &outPage,
+                              GLfloat *coordinates);
+    
+    /*!
+     * Returns the number of texture atlas pages that have been created. Triggers a
+     * layout if none has happened so far.
+     */
+    unsigned long getNumAtlasPages();
+    
+    /*!
+     * Returns height of specified file object texture.
+     */
+    unsigned long getTextureHeight(unsigned long texture) const;
+    
+    /*!
+     * Uploads the current data to OpenGL, as one or more texture pages.
+     * textureNames has to have a length of at least GetNumAtlasPages and will
+     * contain the names of the pages on return.
+     * @param atlas The atlas.
+     * @param textureNames The names of the textures.
+     * @param additionalTextureNames How many texture names to create in addition to the needed ones.
+     */
+    void createTextures(GLuint *textureNames, GLuint additionalTextureNames);
 
-/*!
- * Add a 32-bit 256x256 texture page. The atlas will use it to get the texture
- * data later. It does not copy the data, so this pointer must remain valid at
- * least until @see BorderedTextureAtlas_CreateTextures gets called.
- * @param atlas The atlas
- * @param trpage The data. Must have a size of 256x256x4 = 256 kB, and be stored in RGBA format.
- */
-void BorderedTextureAtlas_AddPage(bordered_texture_atlas_p atlas, void *trpage);
-
-/*!
- * Add the contents of a Tomb Raider object texture. An object texture is how
- * Tomb Raider stores its texture coordinates. As simplification, this method
- * assumes/requires that this region is always an axis aligned rectangle, which
- * is true for all known levels. Only textures that got added through this
- * method will appear in the final result. They must be added in the original
- * order for @see BorderedTextureAtlas_GetCoordinates to work as expected.
- * @param atlas The texture atlas
- * @param texture The object texture.
- */
-void BorderedTextureAtlas_AddObjectTexture(bordered_texture_atlas_p atlas,
-                                           const tr4_object_texture_t *texture);
-
-/*!
- * Same as above, but for sprite textures.
- */
-void BorderedTextureAtlas_AddSpriteTexture(bordered_texture_atlas_p atlas,
-                                           const tr_sprite_texture_t *texture);
-
-/*!
- * Returns the texture coordinates of the specified texture. This must only be
- * called after all pages and object texture coordinates have been added.
- * Otherwise the size calculation code won't work.
- * @param atlas The texture atlas
- * @param texture The texture.
- * @param numCoordinates The number of coordinates you want. Typically 3 (for a triangle) or 4 (for a rectangle). Must be smaller than 5.
- * @param reverse Whether to reverse the order of texture coordinates on output.
- * @param outPage The page in the resulting texture atlas.
- * @param coordiantes The coordinates of the specified texture.
- * you don't think you'll need them all.
- */
-void BorderedTextureAtlas_GetCoordinates(bordered_texture_atlas_p atlas,
-                                         unsigned long texture,
-                                         int reverse,
-                                         polygon_p poly,
-                                         signed shift = 0,
-                                         bool split = false);
-
-/*!
- * Same as above, but for sprite textures. This always returns four coordinates (eight float values), in the order top right, top left, bottom left, bottom right.
- */
-void BorderedTextureAtlas_GetSpriteCoordinates(bordered_texture_atlas_p atlas, unsigned long sprite_texture, uint32_t *outPage, GLfloat *coordinates);
-
-/*!
- * Returns the number of texture atlas pages that have been created. Triggers a
- * layout if none has happened so far.
- */
-unsigned long BorderedTextureAtlas_GetNumAtlasPages(bordered_texture_atlas_p atlas);
-
-/*!
- * Returns height of specified file object texture.
- */
-unsigned long BorderedTextureAtlas_GetTextureHeight(bordered_texture_atlas_p atlas,
-                                                    unsigned long texture);
-
-/*!
- * Uploads the current data to OpenGL, as one or more texture pages.
- * textureNames has to have a length of at least GetNumAtlasPages and will
- * contain the names of the pages on return.
- * @param atlas The atlas.
- * @param textureNames The names of the textures.
- * @param additionalTextureNames How many texture names to create in addition to the needed ones.
- */
-void BorderedTextureAtlas_CreateTextures(bordered_texture_atlas_p atlas, GLuint *textureNames, GLuint additionalTextureNames);
-
-/*!
- * Returns height of desired TexInfo.
- * layout if none has happened so far.
- */
-
-
-#ifdef __cplusplus
-} // extern "C"
-#endif
+};
 
 #endif /* BORDERED_TEXTURE_ATLAS_H */

--- a/src/resource.cpp
+++ b/src/resource.cpp
@@ -2355,22 +2355,13 @@ void TR_GenTextures(struct world_s* world, class VT_Level *tr)
     int border_size = renderer.settings.texture_border;
     border_size = (border_size < 0)?(0):(border_size);
     border_size = (border_size > 128)?(128):(border_size);
-    world->tex_atlas = new bordered_texture_atlas(border_size);                // here is border size
-
-    for(uint32_t i = 0; i < tr->textile32_count; i++)
-    {
-        world->tex_atlas->addPage(tr->textile32[i].pixels);
-    }
-
-    for (uint32_t i = 0; i < tr->sprite_textures_count; i++)
-    {
-        world->tex_atlas->addSpriteTexture(tr->sprite_textures[i]);
-    }
-
-    for (uint32_t i = 0; i < tr->object_textures_count; i++)
-    {
-        world->tex_atlas->addObjectTexture(tr->object_textures[i]);
-    }
+    world->tex_atlas = new bordered_texture_atlas(border_size,
+                                                  tr->textile32_count,
+                                                  tr->textile32,
+                                                  tr->object_textures_count,
+                                                  tr->object_textures,
+                                                  tr->sprite_textures_count,
+                                                  tr->sprite_textures);
 
     world->tex_count = (uint32_t) world->tex_atlas->getNumAtlasPages() + 1;
     world->textures = (GLuint*)malloc(world->tex_count * sizeof(GLuint));

--- a/src/world.cpp
+++ b/src/world.cpp
@@ -572,7 +572,7 @@ void World_Empty(world_p world)
 
     if(world->tex_atlas)
     {
-        BorderedTextureAtlas_Destroy(world->tex_atlas);
+        delete world->tex_atlas;
         world->tex_atlas = NULL;
     }
 

--- a/src/world.h
+++ b/src/world.h
@@ -255,7 +255,7 @@ typedef struct world_s
     uint32_t                    room_flipmap;           // Flipped room activity bit field.
     uint32_t                    room_flipstate;         // Flipped room actual state bit field.
 
-    bordered_texture_atlas_p    tex_atlas;
+    bordered_texture_atlas     *tex_atlas;
     uint32_t                    tex_count;              // Number of textures
     GLuint                     *textures;               // OpenGL textures indexes
 


### PR DESCRIPTION
There were a few architectural decisions about the bordered texture atlas that never sat very well with me, so now I finally took the time to change them.

- The atlas is now a proper C++ class, with constructor, destructor, everything. Cleaner design, makes a lot of code easier to read.
- A lot of details were changed to be in line with C++ standards, such as using bool and references.
- The atlas now takes all its values, meaning the texture pages and individual textures, at startup time and directly lays them out. This should be a bit faster as all memory is only allocated once. It's also a design that is overall more clearer: All work happens on creation; after that everything is read-only. Previously the atlas switched to the read-only mode the first time the result was requested, which was very arbitrary.
- As a result, everything uses a bit less code than it could have.

I did consider using C++ standard library items here, but since they seem unloved in OpenTomb, I wanted to wait for feedback before doing so. Thanks to the other changes, in particular laying out the textures up front, this is no longer really all that necessary.