### PR TITLE
Wall climbing fix

### DIFF
--- a/src/entity.cpp
+++ b/src/entity.cpp
@@ -872,10 +872,14 @@ void Entity_ProcessSector(struct entity_s *ent)
 {
     if(ent->character)
     {
-        ent->character->height_info.walls_climb_dir = ent->current_sector->flags & (SECTOR_FLAG_CLIMB_WEST  |
+        ent->character->height_info.walls_climb_dir = 0;
+        for (struct room_sector_s *sector = ent->current_sector; sector; sector = sector->sector_below)
+        {
+            ent->character->height_info.walls_climb_dir |= sector->flags & (SECTOR_FLAG_CLIMB_WEST  |
                                                                                     SECTOR_FLAG_CLIMB_EAST  |
                                                                                     SECTOR_FLAG_CLIMB_NORTH |
                                                                                     SECTOR_FLAG_CLIMB_SOUTH );
+        }
 
         ent->character->height_info.walls_climb     = (ent->character->height_info.walls_climb_dir > 0);
         ent->character->height_info.ceiling_climb   = 0x00;

--- a/src/resource.cpp
+++ b/src/resource.cpp
@@ -1504,9 +1504,6 @@ void TR_Sector_Calculate(struct world_s *world, class VT_Level *tr, long int roo
         if(rp >= 0 && rp < world->room_count && rp != 255)
         {
             sector->sector_below = Room_GetSectorRaw(world->rooms + rp, sector->pos);
-            
-            // Copy climbability flags from below
-            sector->flags |= sector->sector_below->flags & (SECTOR_FLAG_CLIMB_WEST | SECTOR_FLAG_CLIMB_EAST | SECTOR_FLAG_CLIMB_NORTH | SECTOR_FLAG_CLIMB_SOUTH);
         }
         rp = tr_room->sector_list[i].room_above;
         sector->sector_above = NULL;

--- a/src/resource.cpp
+++ b/src/resource.cpp
@@ -1504,6 +1504,9 @@ void TR_Sector_Calculate(struct world_s *world, class VT_Level *tr, long int roo
         if(rp >= 0 && rp < world->room_count && rp != 255)
         {
             sector->sector_below = Room_GetSectorRaw(world->rooms + rp, sector->pos);
+            
+            // Copy climbability flags from below
+            sector->flags |= sector->sector_below->flags & (SECTOR_FLAG_CLIMB_WEST | SECTOR_FLAG_CLIMB_EAST | SECTOR_FLAG_CLIMB_NORTH | SECTOR_FLAG_CLIMB_SOUTH);
         }
         rp = tr_room->sector_list[i].room_above;
         sector->sector_above = NULL;


### PR DESCRIPTION
This fixes a bug where walls were only climbable in the room that marked them as climbable. The default approach for TR is that a wall is climbable if it is climbable in the room at the bottom of the stack. This was notable e.g. in the TR 2 mansion (the climbable wall leading out of the water), or in TR 2 Venice (BOAT.TR2), in the wooden hut (it was not possible to climb on from the second level) or the weird every-wall-is-climbable place.

(The revision history for this one is a bit longer than expected because I've first tried a different way of fixing the issue, which turned out to work only about 50% of the time. This new version works all the time.)