### PR TITLE
Rendering fixes

### DIFF
--- a/src/entity.cpp
+++ b/src/entity.cpp
@@ -730,7 +730,7 @@ void Entity::updateCurrentBoneFrame(SSBoneFrame *bf, const btTransform* etr)
     btVector3 tr, cmd_tr;
     if(etr && (curr_bf->command & ANIM_CMD_MOVE))
     {
-        tr = *etr * curr_bf->move;
+        tr = etr->getBasis() * curr_bf->move;
         cmd_tr = tr * bf->animations.lerp;
     }
     else
@@ -1236,7 +1236,7 @@ void Entity::doAnimMove(int16_t *anim, int16_t *frame)
         }
         if(curr_bf->command & ANIM_CMD_MOVE)
         {
-            btVector3 tr = m_transform.getOrigin() * curr_bf->move;
+            btVector3 tr = m_transform.getBasis() * curr_bf->move;
             m_transform.getOrigin() += tr;
         }
     }

--- a/src/entity.h
+++ b/src/entity.h
@@ -186,7 +186,9 @@ public:
         return m_transform * v;
     }
     virtual void transferToRoom(Room *room);
-    virtual void frameImpl(btScalar /*time*/, int16_t /*frame*/, int /*state*/) {
+    virtual void frameImpl(btScalar /*time*/, int16_t frame, int /*state*/)
+    {
+        m_bf.animations.current_frame = frame;
     }
 
     virtual void processSectorImpl() {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -437,6 +437,7 @@ void Game_ApplyControls(std::shared_ptr<Entity> ent)
 
         ent->m_angles[0] = 180.0 * cam_angles[0] / M_PI;
         pos = renderer.camera()->m_pos + renderer.camera()->m_viewDir * control_states.cam_distance;
+        pos[2] -= 512.0;
         ent->m_transform.getOrigin() = pos;
         ent->updateTransform();
     }

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -1100,6 +1100,7 @@ void Gui_SwitchGLMode(char is_gui)
         const GLfloat far_dist = 4096.0f;
         const GLfloat near_dist = -1.0f;
 
+        guiProjectionMatrix = matrix4{};                                        // identity matrix
         guiProjectionMatrix[0][0] = 2.0 / ((GLfloat)screen_info.w);
         guiProjectionMatrix[1][1] = 2.0 / ((GLfloat)screen_info.h);
         guiProjectionMatrix[2][2] =-2.0 / (far_dist - near_dist);

--- a/src/polygon.cpp
+++ b/src/polygon.cpp
@@ -103,7 +103,7 @@ void Polygon::vTransform(Polygon* src, const btTransform& tr)
     plane.normal = tr.getBasis() * src->plane.normal;
     for(size_t i=0; i<src->vertices.size(); i++)
     {
-        vertices[i].position = tr * src->vertices[i].position;
+        vertices[i].position = tr.getBasis() * src->vertices[i].position;
     }
 
     plane.moveTo(vertices[0].position);

--- a/src/vmath.cpp
+++ b/src/vmath.cpp
@@ -44,8 +44,8 @@ void Mat4_RotateX(btTransform& mat, btScalar ang)
     btScalar cosa = cos(tmp);
 
     auto m = mat.getBasis().transpose();
-    m[1] = mat.getBasis()[1] * cosa + mat.getBasis()[2] * sina;
-    m[2] =-mat.getBasis()[1] * sina + mat.getBasis()[2] * cosa;
+    m[1] = mat.getBasis().getColumn(1) * cosa + mat.getBasis().getColumn(2) * sina;
+    m[2] =-mat.getBasis().getColumn(1) * sina + mat.getBasis().getColumn(2) * cosa;
     
     mat.getBasis() = m.transpose();
 }
@@ -57,8 +57,8 @@ void Mat4_RotateY(btTransform& mat, btScalar ang)
     btScalar cosa = cos(tmp);
 
     auto m = mat.getBasis().transpose();
-    m[0] = mat.getBasis()[0] * cosa - mat.getBasis()[2] * sina;
-    m[2] = mat.getBasis()[0] * sina + mat.getBasis()[2] * cosa;
+    m[0] = mat.getBasis().getColumn(0) * cosa - mat.getBasis().getColumn(2) * sina;
+    m[2] = mat.getBasis().getColumn(0) * sina + mat.getBasis().getColumn(2) * cosa;
     
     mat.getBasis() = m.transpose();
 }
@@ -70,8 +70,8 @@ void Mat4_RotateZ(btTransform& mat, btScalar ang)
     btScalar cosa = cos(tmp);
 
     auto m = mat.getBasis().transpose();
-    m[0] = mat.getBasis()[0] * cosa + mat.getBasis()[1] * sina;
-    m[1] =-mat.getBasis()[0] * sina + mat.getBasis()[1] * cosa;
+    m[0] = mat.getBasis().getColumn(0) * cosa + mat.getBasis().getColumn(1) * sina;
+    m[1] =-mat.getBasis().getColumn(0) * sina + mat.getBasis().getColumn(1) * cosa;
     
     mat.getBasis() = m.transpose();
 }


### PR DESCRIPTION
Fixes:
- Lara's rolling animation (tested in TR1)
- Lara's position in noclip mode
- animations of entities (bats, doors, levers, ...)
- inventory and item notifier
- position of the zip-line handle (tested in TR2)

All patches are fairly simple and were made just by comparing the code before the C++ merge and after it.