### PR TITLE
move sound related members from World to new struct AudioManager

### DIFF
--- a/src/anim_state_control.cpp
+++ b/src/anim_state_control.cpp
@@ -242,8 +242,8 @@ int State_Control_Lara(Character* character, struct SSAnimation *ss_anim)
 
     if(resp->kill == 1)   // Stop any music, if Lara is dead.
     {
-        Audio_EndStreams(TR_AUDIO_STREAM_TYPE_ONESHOT);
-        Audio_EndStreams(TR_AUDIO_STREAM_TYPE_CHAT);
+        engine_world.audio_manager.endStreams(TR_AUDIO_STREAM_TYPE_ONESHOT);
+        engine_world.audio_manager.endStreams(TR_AUDIO_STREAM_TYPE_CHAT);
     }
 
  /*
@@ -294,7 +294,7 @@ int State_Control_Lara(Character* character, struct SSAnimation *ss_anim)
             }
             else if(resp->slide == CHARACTER_SLIDE_FRONT)
             {
-                Audio_Send(TR_AUDIO_SOUND_LANDING, TR_AUDIO_EMITTER_ENTITY, character->id());
+                engine_world.audio_manager.send(TR_AUDIO_SOUND_LANDING, TR_AUDIO_EMITTER_ENTITY, character->id());
 
                 if(cmd->jump)
                 {
@@ -312,7 +312,7 @@ int State_Control_Lara(Character* character, struct SSAnimation *ss_anim)
                 {
                     character->m_dirFlag = ENT_MOVE_BACKWARD;
                     character->setAnimation(TR_ANIMATION_LARA_JUMP_BACK_BEGIN, 0);
-                    Audio_Send(TR_AUDIO_SOUND_LANDING, TR_AUDIO_EMITTER_ENTITY, character->id());
+                    engine_world.audio_manager.send(TR_AUDIO_SOUND_LANDING, TR_AUDIO_EMITTER_ENTITY, character->id());
                 }
                 else
                 {
@@ -1327,7 +1327,7 @@ int State_Control_Lara(Character* character, struct SSAnimation *ss_anim)
                 break;
             }
 
-            Audio_Kill(TR_AUDIO_SOUND_SLIDING, TR_AUDIO_EMITTER_ENTITY, character->id());
+            engine_world.audio_manager.kill(TR_AUDIO_SOUND_SLIDING, TR_AUDIO_EMITTER_ENTITY, character->id());
             break;
 
         case TR_STATE_LARA_SLIDE_FORWARD:
@@ -1361,7 +1361,7 @@ int State_Control_Lara(Character* character, struct SSAnimation *ss_anim)
                 break;
             }
 
-            Audio_Kill(TR_AUDIO_SOUND_SLIDING, TR_AUDIO_EMITTER_ENTITY, character->id());
+            engine_world.audio_manager.kill(TR_AUDIO_SOUND_SLIDING, TR_AUDIO_EMITTER_ENTITY, character->id());
             break;
 
             /*
@@ -1456,12 +1456,12 @@ int State_Control_Lara(Character* character, struct SSAnimation *ss_anim)
                 {
                     if(was_traversed)
                     {
-                        if(Audio_IsEffectPlaying(TR_AUDIO_SOUND_PUSHABLE,TR_AUDIO_EMITTER_ENTITY,character->id()) == -1)
-                            Audio_Send(TR_AUDIO_SOUND_PUSHABLE, TR_AUDIO_EMITTER_ENTITY, character->id());
+                        if(engine_world.audio_manager.findPlayingSource(TR_AUDIO_SOUND_PUSHABLE,TR_AUDIO_EMITTER_ENTITY,character->id()) == -1)
+                            engine_world.audio_manager.send(TR_AUDIO_SOUND_PUSHABLE, TR_AUDIO_EMITTER_ENTITY, character->id());
                     }
                     else
                     {
-                        Audio_Kill(TR_AUDIO_SOUND_PUSHABLE, TR_AUDIO_EMITTER_ENTITY, character->id());
+                        engine_world.audio_manager.kill(TR_AUDIO_SOUND_PUSHABLE, TR_AUDIO_EMITTER_ENTITY, character->id());
                     }
                 }
                 else
@@ -1470,8 +1470,8 @@ int State_Control_Lara(Character* character, struct SSAnimation *ss_anim)
                         (ss_anim->current_frame == 110)  ||
                         (ss_anim->current_frame == 142)   )
                     {
-                        if(Audio_IsEffectPlaying(TR_AUDIO_SOUND_PUSHABLE,TR_AUDIO_EMITTER_ENTITY,character->id()) == -1)
-                            Audio_Send(TR_AUDIO_SOUND_PUSHABLE, TR_AUDIO_EMITTER_ENTITY, character->id());
+                        if(engine_world.audio_manager.findPlayingSource(TR_AUDIO_SOUND_PUSHABLE,TR_AUDIO_EMITTER_ENTITY,character->id()) == -1)
+                            engine_world.audio_manager.send(TR_AUDIO_SOUND_PUSHABLE, TR_AUDIO_EMITTER_ENTITY, character->id());
                     }
                 }
 
@@ -1481,7 +1481,7 @@ int State_Control_Lara(Character* character, struct SSAnimation *ss_anim)
             {
                 if(engine_world.version > TR_III)
                 {
-                    Audio_Kill(TR_AUDIO_SOUND_PUSHABLE, TR_AUDIO_EMITTER_ENTITY, character->id());
+                    engine_world.audio_manager.kill(TR_AUDIO_SOUND_PUSHABLE, TR_AUDIO_EMITTER_ENTITY, character->id());
                 }
             }
             break;
@@ -1543,13 +1543,13 @@ int State_Control_Lara(Character* character, struct SSAnimation *ss_anim)
                 {
                     if(was_traversed)
                     {
-                        if(Audio_IsEffectPlaying(TR_AUDIO_SOUND_PUSHABLE,TR_AUDIO_EMITTER_ENTITY,character->id()) == -1)
+                        if(engine_world.audio_manager.findPlayingSource(TR_AUDIO_SOUND_PUSHABLE,TR_AUDIO_EMITTER_ENTITY,character->id()) == -1)
 
-                            Audio_Send(TR_AUDIO_SOUND_PUSHABLE, TR_AUDIO_EMITTER_ENTITY, character->id());
+                            engine_world.audio_manager.send(TR_AUDIO_SOUND_PUSHABLE, TR_AUDIO_EMITTER_ENTITY, character->id());
                     }
                     else
                     {
-                        Audio_Kill(TR_AUDIO_SOUND_PUSHABLE, TR_AUDIO_EMITTER_ENTITY, character->id());
+                        engine_world.audio_manager.kill(TR_AUDIO_SOUND_PUSHABLE, TR_AUDIO_EMITTER_ENTITY, character->id());
                     }
                 }
                 else
@@ -1559,8 +1559,8 @@ int State_Control_Lara(Character* character, struct SSAnimation *ss_anim)
                         (ss_anim->current_frame == 124) ||
                         (ss_anim->current_frame == 156)  )
                     {
-                        if(Audio_IsEffectPlaying(TR_AUDIO_SOUND_PUSHABLE,TR_AUDIO_EMITTER_ENTITY,character->id()) == -1)
-                            Audio_Send(TR_AUDIO_SOUND_PUSHABLE, TR_AUDIO_EMITTER_ENTITY, character->id());
+                        if(engine_world.audio_manager.findPlayingSource(TR_AUDIO_SOUND_PUSHABLE,TR_AUDIO_EMITTER_ENTITY,character->id()) == -1)
+                            engine_world.audio_manager.send(TR_AUDIO_SOUND_PUSHABLE, TR_AUDIO_EMITTER_ENTITY, character->id());
                     }
                 }
 
@@ -1570,7 +1570,7 @@ int State_Control_Lara(Character* character, struct SSAnimation *ss_anim)
             {
                 if(engine_world.version > TR_III)
                 {
-                    Audio_Kill(TR_AUDIO_SOUND_PUSHABLE, TR_AUDIO_EMITTER_ENTITY, character->id());
+                    engine_world.audio_manager.kill(TR_AUDIO_SOUND_PUSHABLE, TR_AUDIO_EMITTER_ENTITY, character->id());
                 }
             }
             break;
@@ -2239,7 +2239,7 @@ int State_Control_Lara(Character* character, struct SSAnimation *ss_anim)
                 (int(character->m_speed[2]) >= (-FREE_FALL_SPEED_CRITICAL-100)) )
             {
                 character->m_speed[2] = -FREE_FALL_SPEED_CRITICAL-101;
-                Audio_Send(TR_AUDIO_SOUND_LARASCREAM, TR_AUDIO_EMITTER_ENTITY, character->id());       // Scream
+                engine_world.audio_manager.send(TR_AUDIO_SOUND_LARASCREAM, TR_AUDIO_EMITTER_ENTITY, character->id());       // Scream
             }
             else if(character->m_speed[2] <= -FREE_FALL_SPEED_MAXSAFE)
             {
@@ -2254,12 +2254,12 @@ int State_Control_Lara(Character* character, struct SSAnimation *ss_anim)
                 cmd->rot[1] = 0.0;
                 character->updateTransform();                                     // needed here to fix underwater in wall collision bug
                 character->setAnimation(TR_ANIMATION_LARA_FREE_FALL_TO_UNDERWATER, 0);
-                Audio_Kill(TR_AUDIO_SOUND_LARASCREAM, TR_AUDIO_EMITTER_ENTITY, character->id());       // Stop scream
+                engine_world.audio_manager.kill(TR_AUDIO_SOUND_LARASCREAM, TR_AUDIO_EMITTER_ENTITY, character->id());       // Stop scream
 
                 // Splash sound is hardcoded, beginning with TR3.
                 if(engine_world.version > TR_II)
                 {
-                    Audio_Send(TR_AUDIO_SOUND_SPLASH, TR_AUDIO_EMITTER_ENTITY, character->id());
+                    engine_world.audio_manager.send(TR_AUDIO_SOUND_SPLASH, TR_AUDIO_EMITTER_ENTITY, character->id());
                 }
             }
             else if((resp->vertical_collide & 0x01) || (character->m_moveType == MOVE_ON_FLOOR))
@@ -2267,7 +2267,7 @@ int State_Control_Lara(Character* character, struct SSAnimation *ss_anim)
                 if(character->m_self->room->flags & TR_ROOM_FLAG_QUICKSAND)
                 {
                     character->setAnimation(TR_ANIMATION_LARA_STAY_IDLE, 0);
-                    Audio_Kill(TR_AUDIO_SOUND_LARASCREAM, TR_AUDIO_EMITTER_ENTITY, character->id());
+                    engine_world.audio_manager.kill(TR_AUDIO_SOUND_LARASCREAM, TR_AUDIO_EMITTER_ENTITY, character->id());
                 }
                 else if(character->m_speed[2] <= -FREE_FALL_SPEED_MAXSAFE)
                 {
@@ -2294,7 +2294,7 @@ int State_Control_Lara(Character* character, struct SSAnimation *ss_anim)
                 if(resp->kill == 1)
                 {
                     ss_anim->next_state = TR_STATE_LARA_DEATH;
-                    Audio_Kill(TR_AUDIO_SOUND_LARASCREAM, TR_AUDIO_EMITTER_ENTITY, character->id());
+                    engine_world.audio_manager.kill(TR_AUDIO_SOUND_LARASCREAM, TR_AUDIO_EMITTER_ENTITY, character->id());
                 }
             }
             else if(cmd->action)

--- a/src/console.cpp
+++ b/src/console.cpp
@@ -185,7 +185,7 @@ void ConsoleInfo::edit(int key) {
     case SDLK_DOWN:
         if( m_historyLines.empty() )
             break;
-        Audio_Send(lua_GetGlobalSound(engine_lua, TR_AUDIO_SOUND_GLOBALID_MENUPAGE));
+        engine_world.audio_manager.send(lua_GetGlobalSound(engine_lua, TR_AUDIO_SOUND_GLOBALID_MENUPAGE));
         if( key==SDLK_UP && m_historyPos < m_historyLines.size() )
             ++m_historyPos;
         else if( key==SDLK_DOWN && m_historyPos > 0 )

--- a/src/engine.h
+++ b/src/engine.h
@@ -116,8 +116,6 @@ struct EngineControlState
 extern EngineControlState            control_states;
 extern ControlSettings                control_mapper;
 
-extern AudioSettings                  audio_settings;
-
 extern btScalar                                 engine_frame_time;
 extern Camera                          engine_camera;
 extern World                           engine_world;

--- a/src/entity.cpp
+++ b/src/entity.cpp
@@ -865,16 +865,16 @@ void Entity::doAnimCommands(struct SSAnimation *ss_anim, int /*changing*/)
                     if(pointer[1] & TR_ANIMCOMMAND_CONDITION_WATER)
                     {
                         if(getSubstanceState() == Substance::WaterShallow)
-                            Audio_Send(sound_index, TR_AUDIO_EMITTER_ENTITY, m_id);
+                            engine_world.audio_manager.send(sound_index, TR_AUDIO_EMITTER_ENTITY, m_id);
                     }
                     else if(pointer[1] & TR_ANIMCOMMAND_CONDITION_LAND)
                     {
                         if(getSubstanceState() != Substance::WaterShallow)
-                            Audio_Send(sound_index, TR_AUDIO_EMITTER_ENTITY, m_id);
+                            engine_world.audio_manager.send(sound_index, TR_AUDIO_EMITTER_ENTITY, m_id);
                     }
                     else
                     {
-                        Audio_Send(sound_index, TR_AUDIO_EMITTER_ENTITY, m_id);
+                        engine_world.audio_manager.send(sound_index, TR_AUDIO_EMITTER_ENTITY, m_id);
                     }
 
                 }
@@ -924,28 +924,28 @@ void Entity::doAnimCommands(struct SSAnimation *ss_anim, int /*changing*/)
                             switch(m_currentSector->material)
                             {
                             case SECTOR_MATERIAL_MUD:
-                                Audio_Send(288, TR_AUDIO_EMITTER_ENTITY, m_id);
+                                engine_world.audio_manager.send(288, TR_AUDIO_EMITTER_ENTITY, m_id);
                                 break;
 
                             case SECTOR_MATERIAL_SNOW:  // TR3 & TR5 only
                                 if(engine_world.version != TR_IV)
                                 {
-                                    Audio_Send(293, TR_AUDIO_EMITTER_ENTITY, m_id);
+                                    engine_world.audio_manager.send(293, TR_AUDIO_EMITTER_ENTITY, m_id);
                                 }
                                 break;
 
                             case SECTOR_MATERIAL_SAND:  // Same as grass
-                                Audio_Send(291, TR_AUDIO_EMITTER_ENTITY, m_id);
+                                engine_world.audio_manager.send(291, TR_AUDIO_EMITTER_ENTITY, m_id);
                                 break;
 
                             case SECTOR_MATERIAL_GRAVEL:
-                                Audio_Send(290, TR_AUDIO_EMITTER_ENTITY, m_id);
+                                engine_world.audio_manager.send(290, TR_AUDIO_EMITTER_ENTITY, m_id);
                                 break;
 
                             case SECTOR_MATERIAL_ICE:   // TR3 & TR5 only
                                 if(engine_world.version != TR_IV)
                                 {
-                                    Audio_Send(289, TR_AUDIO_EMITTER_ENTITY, m_id);
+                                    engine_world.audio_manager.send(289, TR_AUDIO_EMITTER_ENTITY, m_id);
                                 }
                                 break;
 
@@ -958,34 +958,34 @@ void Entity::doAnimCommands(struct SSAnimation *ss_anim, int /*changing*/)
                                 break;
 
                             case SECTOR_MATERIAL_WOOD:
-                                Audio_Send(292, TR_AUDIO_EMITTER_ENTITY, m_id);
+                                engine_world.audio_manager.send(292, TR_AUDIO_EMITTER_ENTITY, m_id);
                                 break;
 
                             case SECTOR_MATERIAL_METAL:
-                                Audio_Send(294, TR_AUDIO_EMITTER_ENTITY, m_id);
+                                engine_world.audio_manager.send(294, TR_AUDIO_EMITTER_ENTITY, m_id);
                                 break;
 
                             case SECTOR_MATERIAL_MARBLE:    // TR4 only
                                 if(engine_world.version == TR_IV)
                                 {
-                                    Audio_Send(293, TR_AUDIO_EMITTER_ENTITY, m_id);
+                                    engine_world.audio_manager.send(293, TR_AUDIO_EMITTER_ENTITY, m_id);
                                 }
                                 break;
 
                             case SECTOR_MATERIAL_GRASS:     // Same as sand
-                                Audio_Send(291, TR_AUDIO_EMITTER_ENTITY, m_id);
+                                engine_world.audio_manager.send(291, TR_AUDIO_EMITTER_ENTITY, m_id);
                                 break;
 
                             case SECTOR_MATERIAL_CONCRETE:  // DEFAULT SOUND, BYPASS!
-                                Audio_Send(-1, TR_AUDIO_EMITTER_ENTITY, m_id);
+                                engine_world.audio_manager.send(-1, TR_AUDIO_EMITTER_ENTITY, m_id);
                                 break;
 
                             case SECTOR_MATERIAL_OLDWOOD:   // Same as wood
-                                Audio_Send(292, TR_AUDIO_EMITTER_ENTITY, m_id);
+                                engine_world.audio_manager.send(292, TR_AUDIO_EMITTER_ENTITY, m_id);
                                 break;
 
                             case SECTOR_MATERIAL_OLDMETAL:  // Same as metal
-                                Audio_Send(294, TR_AUDIO_EMITTER_ENTITY, m_id);
+                                engine_world.audio_manager.send(294, TR_AUDIO_EMITTER_ENTITY, m_id);
                                 break;
                             }
                         }
@@ -996,7 +996,7 @@ void Entity::doAnimCommands(struct SSAnimation *ss_anim, int /*changing*/)
                         random_value = rand() % 100;
                         if(random_value > 60)
                         {
-                            Audio_Send(TR_AUDIO_SOUND_BUBBLE, TR_AUDIO_EMITTER_ENTITY, m_id);
+                            engine_world.audio_manager.send(TR_AUDIO_SOUND_BUBBLE, TR_AUDIO_EMITTER_ENTITY, m_id);
                         }
                         break;
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -461,7 +461,7 @@ void Game_ApplyControls(std::shared_ptr<Entity> ent)
             if(ch->getItemsCount(ITEM_SMALL_MEDIPACK) > 0 && ch->changeParam(PARAM_HEALTH, 250))
             {
                 ch->removeItem(ITEM_SMALL_MEDIPACK, 1);
-                Audio_Send(TR_AUDIO_SOUND_MEDIPACK);
+                engine_world.audio_manager.send(TR_AUDIO_SOUND_MEDIPACK);
             }
 
             control_states.use_small_medi = !control_states.use_small_medi;
@@ -473,7 +473,7 @@ void Game_ApplyControls(std::shared_ptr<Entity> ent)
                ch->changeParam(PARAM_HEALTH, LARA_PARAM_HEALTH_MAX))
             {
                 ch->removeItem(ITEM_LARGE_MEDIPACK, 1);
-                Audio_Send(TR_AUDIO_SOUND_MEDIPACK);
+                engine_world.audio_manager.send(TR_AUDIO_SOUND_MEDIPACK);
             }
 
             control_states.use_big_medi = !control_states.use_big_medi;
@@ -791,7 +791,7 @@ void Game_Frame(btScalar time)
     {
         if(game_logic_time >= GAME_LOGIC_REFRESH_INTERVAL)
         {
-            Audio_Update();
+            engine_world.audio_manager.update();
             Game_Tick(&game_logic_time);
         }
         return;
@@ -806,7 +806,7 @@ void Game_Frame(btScalar time)
         btScalar dt = Game_Tick(&game_logic_time);
         lua_DoTasks(engine_lua, dt);
         Game_UpdateAI();
-        Audio_Update();
+        engine_world.audio_manager.update();
 
         if(is_character)
         {
@@ -901,5 +901,5 @@ void Game_LevelTransition(uint16_t level_index)
     Gui_FadeAssignPic(FADER_LOADSCREEN, file_path);
     Gui_FadeStart(FADER_LOADSCREEN, GUI_FADER_DIR_OUT);
 
-    Audio_EndStreams();
+    engine_world.audio_manager.endStreams();
 }

--- a/src/gameflow.cpp
+++ b/src/gameflow.cpp
@@ -44,7 +44,7 @@ void Gameflow_Do()
         {
             case TR_GAMEFLOW_OP_LEVELCOMPLETE:
                 // Switch level only when fade is complete AND all streams / sounds are unloaded!
-                if( (Gui_FadeCheck(FADER_LOADSCREEN) == GUI_FADER_STATUS_COMPLETE) && (!Audio_IsTrackPlaying()) )
+                if( (Gui_FadeCheck(FADER_LOADSCREEN) == GUI_FADER_STATUS_COMPLETE) && !engine_world.audio_manager.isTrackPlaying() )
                 {
                     const char* levelName;
                     const char* levelPath;

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -861,7 +861,7 @@ void gui_InventoryManager::frame(float time)
                     break;
 
                 case INVENTORY_CLOSE:
-                    Audio_Send(lua_GetGlobalSound(engine_lua, TR_AUDIO_SOUND_GLOBALID_MENUCLOSE));
+                    engine_world.audio_manager.send(lua_GetGlobalSound(engine_lua, TR_AUDIO_SOUND_GLOBALID_MENUCLOSE));
                     mLabel_ItemName.show = false;
                     mLabel_Title.show = false;
                     mCurrentState = mNextState;
@@ -869,7 +869,7 @@ void gui_InventoryManager::frame(float time)
 
                 case INVENTORY_R_LEFT:
                 case INVENTORY_R_RIGHT:
-                    Audio_Send(TR_AUDIO_SOUND_MENUROTATE);
+                    engine_world.audio_manager.send(TR_AUDIO_SOUND_MENUROTATE);
                     mLabel_ItemName.show = false;
                     mCurrentState = mNextState;
                     mItemTime = 0.0;
@@ -914,7 +914,7 @@ void gui_InventoryManager::frame(float time)
             {
                 if(setItemsType(mCurrentItemsType) >= 0)
                 {
-                    Audio_Send(lua_GetGlobalSound(engine_lua, TR_AUDIO_SOUND_GLOBALID_MENUOPEN));
+                    engine_world.audio_manager.send(lua_GetGlobalSound(engine_lua, TR_AUDIO_SOUND_GLOBALID_MENUOPEN));
                     mCurrentState = INVENTORY_OPEN;
                     mRingAngle = 180.0;
                     mRingVerticalAngle = 180.0;

--- a/src/main_SDL.cpp
+++ b/src/main_SDL.cpp
@@ -337,7 +337,7 @@ void Engine_InitAL()
         Sys_DebugLog(LOG_FILENAME, " Device: %s", devlist);
         ALCdevice* dev = alcOpenDevice(devlist);
 
-        if(audio_settings.use_effects)
+        if(engine_world.audio_manager.audio_settings.use_effects)
         {
             if( alcIsExtensionPresent(dev, ALC_EXT_EFX_NAME) == ALC_TRUE )
             {
@@ -371,7 +371,7 @@ void Engine_InitAL()
 
     alcMakeContextCurrent(al_context);
 
-    Audio_LoadALExtFunctions(al_device);
+    AudioManager::loadALExtFunctions(al_device);
 
     std::string driver = "OpenAL library: ";
     driver += alcGetString(al_device, ALC_DEVICE_SPECIFIER);

--- a/src/matrix4.h
+++ b/src/matrix4.h
@@ -516,7 +516,7 @@ struct matrix4
 	matrix4() : x(1.0f, 0.0f, 0.0f, 0.0f), y(0.0f, 1.0f, 0.0f, 0.0f), z(0.0f, 0.0f, 1.0f, 0.0f), w(0.0f, 0.0f, 0.0f, 1.0f) {}
 	matrix4(float4 anX, float4 anY, float4 aZ, float4 aW) : x(anX), y(anY), z(aZ), w(aW) {}
 	matrix4(const float *matrix4) { memcpy(c_ptr(), matrix4, sizeof(float [16])); }
-    matrix4(const matrix4 &other) = default;
+    matrix4(const matrix4&) = default;
     
     /*!
      * Create a matrix4 from a btTransform. Note that the reverse is not

--- a/src/world.cpp
+++ b/src/world.cpp
@@ -391,12 +391,8 @@ void World::prepare()
     items_tree.clear();
     character.reset();
 
-    audio_sources.clear();
-    audio_buffers.clear();
-    audio_effects.clear();
+    audio_manager.clear();
     anim_sequences.clear();
-    stream_tracks.clear();
-    stream_track_map.clear();
 
     room_boxes.clear();
     cameras_sinks.clear();
@@ -413,7 +409,7 @@ void World::empty()
     last_cont = NULL;
     Engine_LuaClearTasks();
     // De-initialize and destroy all audio objects.
-    Audio_DeInit();
+    engine_world.audio_manager.deinit();
 
     if(main_inventory_manager != NULL)
     {
@@ -550,7 +546,7 @@ uint32_t World::spawnEntity(uint32_t model_id, uint32_t room_id, const btVector3
         else
         {
             ent = std::make_shared<Entity>(id);
-            if(id+1 > next_entity_id)
+            if(static_cast<uint32_t>(id+1) > next_entity_id)
               next_entity_id = id+1;
         }
 

--- a/src/world.h
+++ b/src/world.h
@@ -390,14 +390,7 @@ struct World
 
     std::vector<int16_t> anim_commands;
 
-    std::vector<AudioEmitter> audio_emitters;         // Audio emitters.
-    std::vector<int16_t> audio_map;              // Effect indexes.
-    std::vector<AudioEffect> audio_effects;          // Effects and their parameters.
-
-    std::vector<ALuint> audio_buffers;          // Samples.
-    std::vector<AudioSource> audio_sources;          // Channels.
-    std::vector<StreamTrack> stream_tracks;          // Stream tracks.
-    std::vector<uint8_t> stream_track_map;       // Stream track flag map.
+    AudioManager audio_manager;
 
     void updateAnimTextures();
     void calculateWaterTint(float* tint, bool fixed_colour);


### PR DESCRIPTION
At least on windows, I often get an out-of-memory message from OpenAL, and we generally have some crippling noise and also rare memory corruptions. This is a first approach for decoupling the audio interface from the engine.