### PR TITLE
SDL mousemode cleanup, added separate mouse axis scaling

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -43,6 +43,8 @@ system =
 controls =
 {
     mouse_sensitivity = 25.0;
+    mouse_scale_x = 0.01;
+    mouse_scale_y = 0.01;
 
     use_joy = true;                 -- Use joystick
     joy_number = 0;                 -- If you have one joystick in system, it will be 0.

--- a/src/controls.cpp
+++ b/src/controls.cpp
@@ -122,14 +122,12 @@ void Controls_Key(int32_t button, bool state)
                         if(ConsoleInfo::instance().isVisible())
                         {
                             //Audio_Send(lua_GetGlobalSound(engine_lua, TR_AUDIO_SOUND_GLOBALID_MENUOPEN));
-                            SDL_ShowCursor(1);
                             SDL_SetRelativeMouseMode(SDL_FALSE);
                             SDL_StartTextInput();
                         }
                         else
                         {
                             //Audio_Send(lua_GetGlobalSound(engine_lua, TR_AUDIO_SOUND_GLOBALID_MENUCLOSE));
-                            SDL_ShowCursor(0);
                             SDL_SetRelativeMouseMode(SDL_TRUE);
                             SDL_StopTextInput();
                         }
@@ -453,32 +451,17 @@ void Controls_InitGlobals()
 void Controls_PollSDLInput()
 {
     SDL_Event event;
-    static int mouse_setup = 0;
 
     while(SDL_PollEvent(&event))
     {
         switch(event.type)
         {
             case SDL_MOUSEMOTION:
-                if(!ConsoleInfo::instance().isVisible() && control_states.mouse_look &&
-                   ((event.motion.x != (screen_info.w / 2)) ||
-                    (event.motion.y != (screen_info.h / 2))))
+                if(!ConsoleInfo::instance().isVisible() && control_states.mouse_look)
                 {
-                    if(mouse_setup)                                             // it is not perfect way, but cursor
-                    {                                                           // every engine start is in one place
-                        control_states.look_axis_x = event.motion.xrel * control_mapper.mouse_sensitivity * 0.01f;
-                        control_states.look_axis_y = event.motion.yrel * control_mapper.mouse_sensitivity * 0.01f;
-                    }
-
-                    if((event.motion.x < ((screen_info.w / 2) - (screen_info.w / 4))) ||
-                       (event.motion.x >((screen_info.w / 2) + (screen_info.w / 4))) ||
-                       (event.motion.y < ((screen_info.h / 2) - (screen_info.h / 4))) ||
-                       (event.motion.y >((screen_info.h / 2) + (screen_info.h / 4))))
-                    {
-                        SDL_WarpMouseInWindow(sdl_window, screen_info.w / 2, screen_info.h / 2);
-                    }
+                        control_states.look_axis_x = event.motion.xrel * control_mapper.mouse_sensitivity * control_mapper.mouse_scale_x;
+                        control_states.look_axis_y = event.motion.yrel * control_mapper.mouse_sensitivity * control_mapper.mouse_scale_y;
                 }
-                mouse_setup = 1;
                 break;
 
             case SDL_MOUSEBUTTONDOWN:

--- a/src/controls.h
+++ b/src/controls.h
@@ -89,6 +89,8 @@ struct ControlAction
 struct ControlSettings
 {
     float    mouse_sensitivity = 0;
+    float    mouse_scale_x = 0.01f;
+    float    mouse_scale_y = 0.01f;
 
     // Global joystick settings.
     bool   use_joy = 0;

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -410,12 +410,7 @@ void Engine_Start()
     // Clearing up memory for initial level loading.
     engine_world.prepare();
 
-#ifdef NDEBUG
-    // Setting up mouse.
     SDL_SetRelativeMouseMode(SDL_TRUE);
-    SDL_WarpMouseInWindow(sdl_window, screen_info.w / 2, screen_info.h / 2);
-    SDL_ShowCursor(0);
-#endif
 
     // Make splash screen.
     Gui_FadeAssignPic(FADER_LOADSCREEN, "resource/graphics/legal.png");

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -3610,6 +3610,8 @@ void script::MainEngine::execEffect(int id, int caller, int operand)
 void script::ScriptEngine::parseControls(struct ControlSettings *cs)
 {
     cs->mouse_sensitivity = (*this)["controls"]["mouse_sensitivity"];
+    cs->mouse_scale_x = (*this)["controls"]["mouse_scale_x"];
+    cs->mouse_scale_y = (*this)["controls"]["mouse_scale_y"];
     cs->use_joy = (*this)["controls"]["use_joy"];
     cs->joy_number = (*this)["controls"]["joy_number"];
     cs->joy_rumble = (*this)["controls"]["joy_rumble"];


### PR DESCRIPTION
Removed some unneeded mouse-event handling: SDL_SetRelativeMouseMode already does the pointer hiding/warping and warp-reset filtering by itself, no need to do that in the event handling.

I also added configuration options for the axis scaling (this also allows to easily invert Y-axis via config with a negative scale...) - because it affects the same code part no separate pullreq for that :blush: