### PR TITLE
added missing break in fader init

### DIFF
--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -214,6 +214,7 @@ void Gui_InitFaders()
                 Fader[i].SetBlendingMode(loader::BlendingMode::Multiply);
                 Fader[i].SetSpeed(10, 800);
             }
+            break;
 
             case FADER_BLACK:
             {


### PR DESCRIPTION
Found by CDT's code analysis, fixes flashStart() without flashSetup() wrongly doing a fade-to-black.