### PR TITLE
cmake: added build type selection, build exe in base dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,11 @@ cmake_minimum_required(VERSION 2.8)
 
 project(OpenTomb)
 
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Debug CACHE STRING "Build type" FORCE)
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS Debug Release MinSizeRel RelWithDebInfo)
+endif()
+
 if(APPLE)
     file(GLOB OPENAL_SRC
         3rdparty/al/*.c

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -88,6 +88,8 @@ target_link_libraries(
     # efence
 )
 
+set_target_properties(${PROJECT_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR})
+
 if(CMAKE_COMPILER_IS_GNUCC)
     target_compile_options(${PROJECT_NAME} PRIVATE -std=gnu++11 -Wall -Wextra -msse3)
 elseif(MSVC)


### PR DESCRIPTION
Setting the build type will generate the appropriate optimize-flags for compilation.
I also changed the build directory for the executable (was in src/, is now in the base dir, where it can be directly run)

<!---
@huboard:{"order":300.0,"milestone_order":300,"custom_state":""}
-->
