### PR TITLE
Remove Mac OS-specific #ifdefs

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -99,10 +99,6 @@ void ShowDebugInfo();
 
 void Engine_Start(const char *config_name)
 {
-#if defined(__MACOSX__)
-    FindConfigFile();
-#endif
-
     Engine_InitDefaultGlobals();
     Engine_LoadConfig(config_name);
 
@@ -114,9 +110,7 @@ void Engine_Start(const char *config_name)
     Engine_InitSDLVideo();
     Engine_InitAL();
 
-#if !defined(__MACOSX__)
     Engine_InitSDLImage();
-#endif
 
     // Additional OpenGL initialization.
     Engine_InitGL();
@@ -315,7 +309,6 @@ void Engine_InitAL()
 }
 
 
-#if !defined(__MACOSX__)
 void Engine_InitSDLImage()
 {
     int flags = IMG_INIT_JPG | IMG_INIT_PNG;
@@ -326,7 +319,6 @@ void Engine_InitSDLImage()
         Sys_DebugLog(SYS_LOG_FILENAME, "SDL_Image error: failed to initialize JPG and/or PNG support.");
     }
 }
-#endif
 
 
 void Engine_InitSDLVideo()


### PR DESCRIPTION
These code pieces tried to do two different things, neither of which makes any sense:

-   Set up the current working directory to some external location to find files there
    more easily. This uses a function that is not actually in the repository, and can thus
    never work.

-   Avoid using SDL_image, because there were special code paths for OS X to use CoreImage
    for saving. This code path is gone (and I think they should stay gone), so this lack of
    initialization is definitely wrong.

This means mostly that the OS X version now uses the same source codes as all other
versions, which makes an awful lot of sense. However, it does not mean the Mac version works
yet.

There are no effects on other platforms.