### PR TITLE
Use custom find_module for SDL2_image instead of PkgConfig.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,9 +65,8 @@ endif()
 #target_compile_options(OpenTomb PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-std=c++11> $<$<COMPILE_LANGUAGE:C>:-std=c99>)
 set_target_properties(OpenTomb PROPERTIES C_STANDARD 99 CXX_STANDARD 11)
 
-include(FindPkgConfig)
-pkg_search_module(SDL2_IMAGE REQUIRED SDL2_image)
 find_package(SDL2 REQUIRED)
+find_package(SDL2_image REQUIRED)
 find_package(OpenAL REQUIRED)
 find_package(ZLIB REQUIRED)
 find_package(Lua REQUIRED)
@@ -75,7 +74,7 @@ find_package(Lua REQUIRED)
 target_include_directories(
     OpenTomb PRIVATE
     ${SDL2_INCLUDE_DIR}
-    ${SDL2_IMAGE_INCLUDE_DIRS}
+    ${SDL2_IMAGE_INCLUDE_DIR}
     ${ZLIB_INCLUDE_DIR}
     ${LUA_INCLUDE_DIR}
     # this is a workaround
@@ -84,7 +83,7 @@ target_include_directories(
     extern/al
 )
 
-target_link_libraries(OpenTomb ${SDL2_LIBRARY} ${SDL2_IMAGE_LIBRARIES} ${ZLIB_LIBRARY} ${LUA_LIBRARY} ${OPENAL_LIBRARY})
+target_link_libraries(OpenTomb ${SDL2_LIBRARY} ${SDL2_IMAGE_LIBRARY} ${ZLIB_LIBRARY} ${LUA_LIBRARY} ${OPENAL_LIBRARY})
 
 set(BULLET_SRCS
     extern/bullet/BulletCollision/BroadphaseCollision/btAxisSweep3.cpp

--- a/cmake/FindSDL2_image.cmake
+++ b/cmake/FindSDL2_image.cmake
@@ -1,0 +1,28 @@
+# - Try to find SDL2_image
+# Once done this will define
+#  SDL2_IMAGE_FOUND - System has SDL2_image
+#  SDL2_IMAGE_INCLUDE_DIRS - The SDL2_image include directories
+#  SDL2_IMAGE_LIBRARIES - The libraries needed to use SDL2_image
+#  SDL2_IMAGE_DEFINITIONS - Compiler switches required for using SDL2_image
+
+SET(SDL2_IMAGE_SEARCH_PATHS
+/usr/local
+/usr
+/sw # Fink
+/opt/local # DarwinPorts
+/opt/csw # Blastwave
+/opt
+)
+
+FIND_PATH(SDL2_IMAGE_INCLUDE_DIR SDL_image.h
+HINTS
+PATH_SUFFIXES include/SDL2 include
+PATHS ${SDL2_IMAGE_SEARCH_PATHS}
+)
+
+FIND_LIBRARY(SDL2_IMAGE_LIBRARY
+NAMES SDL2_image
+HINTS
+PATH_SUFFIXES lib64 lib
+PATHS ${SDL2_IMAGE_SEARCH_PATHS}
+)


### PR DESCRIPTION
PkgConfig seems to sort of find SDL2_image, but not the correct path to the library on
Mac OS. The custom find module solves this issue. It also has the side-effect of
removing the reliance on pkg-config as an external tool. That may not be important at
all (I never had a problem with pkg-config not being installed, even on Mac OS), but
it's still nice.

I have no idea how well this interacts with using special environment variables to specify a custom location for SDL, or how it should interact at all. It may be necessary to expand the find script for this if this turns out to be an issue.