### PR TITLE
Add the headers of our files to CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,41 +15,72 @@ add_subdirectory(doc)
 
 set(OPENTOMB_SRCS
     src/anim_state_control.cpp
+    src/anim_state_control.h
     src/audio.cpp
+    src/audio.h
     src/character_controller.cpp
+    src/character_controller.h
     src/controls.cpp
+    src/controls.h
     src/engine.cpp
+    src/engine.h
+    src/engine_string.h
     src/entity.cpp
+    src/entity.h
     src/game.cpp
+    src/game.h
     src/gameflow.cpp
+    src/gameflow.h
     src/gui.cpp
+    src/gui.h
     src/inventory.cpp
+    src/inventory.h
     src/main_SDL.cpp
     src/mesh.c
+    src/mesh.h
+    src/physics.h
     src/physics_bullet.cpp
     src/render/bordered_texture_atlas.cpp
+    src/render/bordered_texture_atlas.h
     src/render/bsp_tree.cpp
+    src/render/bsp_tree.h
     src/render/bsp_tree_2d.c
+    src/render/bsp_tree_2d.h
     src/render/camera.cpp
+    src/render/camera.h
     src/render/frustum.cpp
+    src/render/frustum.h
     src/render/render.cpp
+    src/render/render.h
     src/render/shader_description.cpp
+    src/render/shader_description.h
     src/render/shader_manager.cpp
+    src/render/bsp_tree_2d.c
+    src/render/shader_manager.h
     src/resource.cpp
+    src/resource.h
     src/room.cpp
+    src/room.h
     src/script.cpp
+    src/script.h
+    src/skeletal_model.h
     src/skeletal_model.c
     src/trigger.cpp
+    src/trigger.h
     src/vt/l_common.cpp
     src/vt/l_main.cpp
+    src/vt/l_main.h
     src/vt/l_tr1.cpp
     src/vt/l_tr2.cpp
     src/vt/l_tr3.cpp
     src/vt/l_tr4.cpp
     src/vt/l_tr5.cpp
     src/vt/scaler.cpp
+    src/vt/scaler.h
     src/vt/vt_level.cpp
+    src/vt/vt_level.h
     src/world.cpp
+    src/world.h
 )
 
 # TODO Where is this needed?
@@ -365,15 +396,25 @@ set(OPENAL_SRCS
 
 set(CORE_SRCS
     src/core/console.c
+    src/core/console.h
     src/core/gl_font.c
+    src/core/gl_font.h
     src/core/gl_text.c
+    src/core/gl_text.h
     src/core/gl_util.c
+    src/core/gl_util.h
     src/core/obb.c
+    src/core/obb.h
     src/core/polygon.c
+    src/core/polygon.h
     src/core/redblack.c
+    src/core/redblack.h
     src/core/system.c
+    src/core/system.h
     src/core/utf8_32.c
+    src/core/utf8_32.h
     src/core/vmath.c
+    src/core/vmath.h
 )
 
 add_library(core OBJECT ${CORE_SRCS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,8 @@ set(OPENTOMB_SRCS
     src/vt/scaler.h
     src/vt/vt_level.cpp
     src/vt/vt_level.h
+    src/vt/tr_types.h
+    src/vt/tr_versions.h
     src/world.cpp
     src/world.h
 )


### PR DESCRIPTION
The header files do not need to be compiled, so it may not seem like they need to be in CMakeLists.txt, but that is wrong. Changes to them still trigger recompiles elsewhere, so CMake needs to be aware of them to include them in the generated dependency tracking. Also, without this, the headers aren't in the generated IDE files, which makes life surprisingly annoying.

This is completely independent of #348, and I expect no issues with merging this.