### PR TITLE
Add proper newlines to debug log.

### DIFF
--- a/src/core/system.c
+++ b/src/core/system.c
@@ -170,11 +170,21 @@ void Sys_DebugLog(const char *file, const char *fmt, ...)
     va_list argptr;
     static char data[4096];
     FILE *fp;
+    size_t len;
 
     va_start(argptr, fmt);
-    data[0] = '\n';
     vsnprintf(data, sizeof(data), fmt, argptr);
     va_end(argptr);
+    
+    // Add newline at end (if possible)
+    len = strlen(data);
+    if ((len + 1) < sizeof(data))
+    {
+        data[len + 0] = '\n';
+        data[len + 1] = 0;
+        len += 1;
+    }
+    
     fp = fopen(file, "a");
     if(fp == NULL)
     {
@@ -182,10 +192,10 @@ void Sys_DebugLog(const char *file, const char *fmt, ...)
     }
     if(fp != NULL)
     {
-        fwrite(data, strlen(data), 1, fp);
+        fwrite(data, len, 1, fp);
         fclose(fp);
     }
-    fwrite(data, strlen(data), 1, stderr);
+    fwrite(data, len, 1, stderr);
 }
 
 


### PR DESCRIPTION
The previous code attempted to add a newline at the start, which then got immediately overwritten by the
following code. The new code adds a newline at the end, which actually works. This was just a minor thing that annoyed me.

(cherry picked from commit c95f7fd49efb500f849815be24eccf37e08e89b2)