### PR TITLE
Update npc_behaviour.asc

### DIFF
--- a/doc/npc_behaviour.asc
+++ b/doc/npc_behaviour.asc
@@ -79,7 +79,7 @@ struct tr_box   // 20 bytes
     uint32_t Xmin;
     uint32_t Xmax;
      int16_t TrueFloor;     // Height value in global units
-     int16_t OverlapIndex;  // Index into Overlaps[].
+     int16_t OverlapIndex;  // bit 0..14 is the index into Overlaps[], bit 15 is unknown (may occur behind a door)
 };
 ----
 
@@ -93,7 +93,7 @@ struct tr2_box   // 8 bytes
     uint8_t Xmin;
     uint8_t Xmax;
     int16_t TrueFloor;     // Height value in global units
-    int16_t OverlapIndex;  // Index into Overlaps[]. 
+    int16_t OverlapIndex;  // Index into Overlaps[] (asme as tr_box?) 
 };
 ----
 

--- a/doc/npc_behaviour.asc
+++ b/doc/npc_behaviour.asc
@@ -93,7 +93,7 @@ struct tr2_box   // 8 bytes
     uint8_t Xmin;
     uint8_t Xmax;
     int16_t TrueFloor;     // Height value in global units
-    int16_t OverlapIndex;  // Index into Overlaps[] (asme as tr_box?) 
+    int16_t OverlapIndex;  // Index into Overlaps[] (same as tr_box?) 
 };
 ----
 

--- a/doc/npc_behaviour.asc
+++ b/doc/npc_behaviour.asc
@@ -79,7 +79,7 @@ struct tr_box   // 20 bytes
     uint32_t Xmin;
     uint32_t Xmax;
      int16_t TrueFloor;     // Height value in global units
-     int16_t OverlapIndex;  // bit 0..14 is the index into Overlaps[], bit 15 is unknown (may occur behind a door)
+    uint16_t OverlapIndex;  // bit 0..14 is the index into Overlaps[], bit 15 is unknown (may occur behind a door)
 };
 ----
 


### PR DESCRIPTION
In TR1, bit 15 of tr_box.OverlapIndex must be skipped to get real index in the overlap array. bit-15 is unknown, it may occur behind a door, I've no idea for what... yet