### PR TITLE
Update mesh_construction_animation.asc

### DIFF
--- a/doc/mesh_construction_animation.asc
+++ b/doc/mesh_construction_animation.asc
@@ -268,8 +268,7 @@ format:
 ----
 struct tr_anim_frame    // Variable size
 {
-     int16_t BB1x, BB1y, BB1z; // Bounding box (low)
-     int16_t BB2x, BB2y, BB2z; // Bounding box (high)
+     tr_bounding_box box; // Bounding box
      int16_t OffsetX, OffsetY, OffsetZ; // Starting offset for this model
      int16_t NumValues;
     uint16_t AngleSets[];   // Variable size


### PR DESCRIPTION
tr_anim_frame bounding box has interleaved min & max components as well as tr_staticmesh
you can see result on the screenshot with entity bbox (white), static mesh collision (red) & visibility (yellow)

![image](https://cloud.githubusercontent.com/assets/796763/18469906/b097def6-79b2-11e6-8e44-e15ab55ea1cb.png)


<!---
@huboard:{"order":94.48110283462205,"milestone_order":382,"custom_state":"ready"}
-->
