### PR TITLE
If the config.lua file is not found then there is

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -177,10 +177,10 @@ void Engine_Start(int argc, char **argv)
         }
     }
 
-    Engine_LoadConfig(config_name ? config_name : "config.lua");
-
     // Primary initialization.
     Engine_Init_Pre();
+
+    Engine_LoadConfig(config_name ? config_name : "config.lua");
 
     // Init generic SDL interfaces.
     Engine_InitSDLControls();


### PR DESCRIPTION
a logging attempt donw but it leads to segfaulting
since some allocations done in Engine_Init_Pre
are needed for it, thus swapping their places here.