### PR TITLE
Linkify README.md table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,20 +5,18 @@ OpenTomb — an open-source Tomb Raider 1-5 engine remake
 
 ### Table of contents ###
 
-1. What is this?
-2. Why it's developed?
-3. Features
-4. Supported platforms
-5. Configuration and autoexec files
-6. Installation and running
-7. Compiling
-8. Licensing
-9. Credits
+- [What is this?](#what-is-this)
+- [Why it's developed?](#why-its-developed)
+- [Features](#features)
+- [Supported platforms](#supported-platforms)
+- [Configuration and autoexec files](#configuration-and-autoexec-files)
+- [Installation and running](#installation-and-running)
+- [Compiling](#compiling)
+- [Licensing](#licensing)
+- [Credits](#credits)
 
 
-1. What is this?
-----------------
-
+### What is this? ###
 OpenTomb is an open-source engine reimplementation project intended to play levels from all
 classic-era Tomb Raider games (TR 1—5) and custom TRLE levels. The project does not use any
 old Tomb Raider source code, because all attempts to retrieve sources from Eidos / Core were
@@ -34,9 +32,7 @@ contemporary updates, features and additions — to fully benefit from being run
 PCs with powerful CPUs and graphic cards — unlike original engines, which are getting older
 and older (original engine, on which all classics were based, will turn 20 next year).
 
-2. Why it's developed?
-----------------------
-
+### Why it's developed? ###
 Many may ask — why develop another TR engine clone, while we have fully working Windows
 builds of TR2-5, and TR1 is perfectly working through DosBox? The answer is simple - the
 older engine gets, less chance it'll become compatible with further systems; but in case of
@@ -47,9 +43,7 @@ engines, like TREP, TRNG, etc.? The answer is simple — no matter how advanced 
 is, you are limited by original binary — no new features, no graphic enhancements, no new
 structures and functions. You are not that limited with open-source engine.
 
-3. Features
------------
-
+### Features ###
 * OpenTomb has completely different collision approach. Engine uses special terrain
   generator to make every room's optimized collisional mesh from so-called "floordata",
   which was a significant limiting factor in originals.  
@@ -63,15 +57,11 @@ structures and functions. You are not that limited with open-source engine.
   unused items, hidden PSX-specific structures inside level files, and so on! Also, original
   functionality is being drastically extended, while preserving original gameplay pipeline.
 
-4. Supported platforms
-----------------------
-
+### Supported platforms ###
 OpenTomb is a cross-platform engine — currently, you can run it on Windows, Mac or Linux.
 No mobile implementations are made yet, but they are fully possible.
 
-5. Configuration and autoexec files
------------------------------------
-
+### Configuration and autoexec files ###
 Currently, all settings in OpenTomb are managed through configuration and autoexec files.
 Configuration file contains persistent engine and game settings, while autoexec contains
 any commands which should be executed on engine start-up.
@@ -84,9 +74,7 @@ just like you type them in the console. Basically, you shouldn't remove any exis
 from autoexec, as most likely engine won't start properly then, but you can modify these
 commands or add new ones — like changing start-up level by modifying setgamef() command.
 
-6. Installation and running
----------------------------
-
+### Installation and running ###
 You don't need to install OpenTomb, but you need all classic TR game resources. Problem is,
 these resources (except level files themselves) are tend to be in some cryptic formats or
 incompatible across game versions. Because of this, you need to convert some game resources
@@ -112,9 +100,7 @@ assets and where to get them:
    Just put it right into OpenTomb directory, and that should do the trick. Note: engine supports 
    png and pcx format of screen images.
     
-7. Compiling
-------------
-
+### Compiling ###
 There is a CMakeLists.txt file provided with source code, so you can compile OpenTomb using
 CMake. On Windows, you can also compile it from Code::Blocks IDE (project file is also provided).
 Alternatively, you can manually compile it in Code::Blocks by recursively adding all source files
@@ -144,9 +130,7 @@ You may use CPU-specific optimization flags (-march=prescott, -march=i486, -marc
 as well as general optimization flags (-O1 and -O2), but DON'T USE -O3 flag, as Bullet tends to
 crash with this optimization level (GCC 5.1+ may compile it without errors).
 
-8. Licensing
-------------
-
+### Licensing ###
 OpenTomb is an open-source engine distributed under LGPLv3 license, which means that ANY part of
 the source code must be open-source as well. Hence, all used libraries and bundled resources must
 be open-source with GPL-compatible licenses. Here is the list of used libraries and resources and
@@ -161,9 +145,7 @@ their licenses:
 
 * Droid Sans Mono, Roboto Condensed Regular and Roboto Regular fonts — Apache
     
-9. Credits
-----------
-
+### Credits ###
 NB: Please note that authors and contributors list is constantly extending, as there is more and
 more people involved in project development, so someone may be missing from this list!
 


### PR DESCRIPTION
- Make the readme easier to read.
- Make the readme easier to navigate.
- Allow linking to specific sections of the readme.
- Fix bug in readme markdown that caused the "What is this?" heading to be shown as item 10 of the TOC.