### PR TITLE
Add option to invert mouse x/y axis

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -36,6 +36,8 @@ render =
 controls =
 {
     mouse_sensitivity = 25.0;
+    mouse_invert_x = 0;
+    mouse_invert_y = 0;
 
     use_joy = 0;                                -- Use joystick - yes (1) or no (0)
     joy_number = 0;                             -- If you have one joystick in system, it will be 0.

--- a/src/controls.cpp
+++ b/src/controls.cpp
@@ -399,6 +399,8 @@ void Controls_RefreshStates()
 void Controls_InitGlobals()
 {
     control_mapper.mouse_sensitivity = 25.0;
+    control_mapper.mouse_invert_x = 0;
+    control_mapper.mouse_invert_y = 0;
     control_mapper.use_joy = 0;
 
     control_mapper.joy_number = 0;              ///@FIXME: Replace with joystick scanner default value when done.

--- a/src/controls.h
+++ b/src/controls.h
@@ -87,6 +87,8 @@ typedef struct control_action_s
 typedef struct control_settings_s
 {
     float       mouse_sensitivity;
+    int8_t      mouse_invert_x;
+    int8_t      mouse_invert_y;
 
     // Global joystick settings.
     int8_t      use_joy;

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -678,8 +678,8 @@ void Engine_PollSDLEvents()
                 {
                     if(mouse_setup)                                             // it is not perfect way, but cursor
                     {                                                           // every engine start is in one place
-                        control_states.look_axis_x = event.motion.xrel * control_mapper.mouse_sensitivity * 0.01;
-                        control_states.look_axis_y = event.motion.yrel * control_mapper.mouse_sensitivity * 0.01;
+                        control_states.look_axis_x = event.motion.xrel * (control_mapper.mouse_invert_x ? -1 : 1) * control_mapper.mouse_sensitivity * 0.01;
+                        control_states.look_axis_y = event.motion.yrel * (control_mapper.mouse_invert_y ? -1 : 1) * control_mapper.mouse_sensitivity * 0.01;
                     }
 
                     if((event.motion.x < ((screen_info.w / 2) - (screen_info.w / 4))) ||

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -277,6 +277,14 @@ int Script_ParseControls(lua_State *lua, struct control_settings_s *cs)
         cs->mouse_sensitivity = lua_tonumber(lua, -1);
         lua_pop(lua, 1);
 
+        lua_getfield(lua, -1, "mouse_invert_x");
+        cs->mouse_invert_x = lua_tonumber(lua, -1);
+        lua_pop(lua, 1);
+
+        lua_getfield(lua, -1, "mouse_invert_y");
+        cs->mouse_invert_y = lua_tonumber(lua, -1);
+        lua_pop(lua, 1);
+
         lua_getfield(lua, -1, "use_joy");
         cs->use_joy = lua_tonumber(lua, -1);
         lua_pop(lua, 1);


### PR DESCRIPTION
Added options mouse_invert_x and mouse_invert_y that allow the x or y axis to be reversed for mouse camera control.