### PR TITLE
Improved inclusion of OpenAL files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,7 +182,6 @@ if(MINGW AND CMAKE_CROSSCOMPILING)
     # Cross compiling on Linux with the MinGW toolchain.
     message(STATUS "MinGW Cross-Compilation")
 
-    set(OPENAL_INCLUDE_DIR "/usr/${COMPILER_PREFIX}/include/AL")
     set(OPENAL_LIBRARY OpenAL32)
 
     set(SDL2_INCLUDE_DIR "/usr/${COMPILER_PREFIX}/include/SDL2")

--- a/cmake/Toolchain-cross-mingw32-linux.cmake
+++ b/cmake/Toolchain-cross-mingw32-linux.cmake
@@ -5,16 +5,22 @@
 SET(CMAKE_SYSTEM_NAME Windows)
 
 # the classical mingw32 (http://www.mingw.org/)
-#SET(COMPILER_PREFIX "i586-mingw32msvc")
+#SET(TOOLCHAIN_PREFIX "i586-mingw32msvc")
 
 # 32 or 64 bits mingw-w64 (http://mingw-w64.sourceforge.net/)
-SET(COMPILER_PREFIX "i686-w64-mingw32")
-#SET(COMPILER_PREFIX "x86_64-w64-mingw32"
+SET(TOOLCHAIN_PREFIX "i686-w64-mingw32")
+#SET(TOOLCHAIN_PREFIX "x86_64-w64-mingw32"
+
+# Toolchain path prefix (CYGWIN cross compiler)
+#SET(COMPILER_PREFIX ${TOOLCHAIN_PREFIX}/sys-root/mingw)
+
+# Toolchain path prefix (standard prefix)
+SET(COMPILER_PREFIX ${TOOLCHAIN_PREFIX})
 
 # compilers to use for C and C++
-FIND_PROGRAM(CMAKE_C_COMPILER NAMES ${COMPILER_PREFIX}-gcc)
-FIND_PROGRAM(CMAKE_CXX_COMPILER NAMES ${COMPILER_PREFIX}-g++)
-FIND_PROGRAM(CMAKE_RC_COMPILER NAMES ${COMPILER_PREFIX}-windres)
+FIND_PROGRAM(CMAKE_C_COMPILER NAMES ${TOOLCHAIN_PREFIX}-gcc)
+FIND_PROGRAM(CMAKE_CXX_COMPILER NAMES ${TOOLCHAIN_PREFIX}-g++)
+FIND_PROGRAM(CMAKE_RC_COMPILER NAMES ${TOOLCHAIN_PREFIX}-windres)
 
 # path to the target environment
 SET(CMAKE_FIND_ROOT_PATH /usr/${COMPILER_PREFIX})

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -6,24 +6,10 @@
 
 #include "../config-opentomb.h"
 
-extern "C" {
-#include <al.h>
-#include <alc.h>
-#ifdef HAVE_ALEXT_H
-#include <alext.h>
-#endif
-#ifdef HAVE_EFX_H
-#include <efx.h>
-#endif
-#ifdef HAVE_EFX_PRESETS_H
-#include <efx-presets.h>
-#endif
-
 #include <codec.h>
 #include <ogg.h>
 #include <os_types.h>
 #include <vorbisfile.h>
-}
 
 #include "../core/system.h"
 #include "../core/vmath.h"
@@ -38,6 +24,7 @@ extern "C" {
 #include "../engine.h"
 #include "../game.h"
 
+#include "audio_al.h"
 #include "audio.h"
 #include "audio_stream.h"
 #include "audio_fx.h"

--- a/src/audio/audio_al.h
+++ b/src/audio/audio_al.h
@@ -1,0 +1,28 @@
+#ifndef AUDIO_AL_H
+#define AUDIO_AL_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <AL/al.h>
+#include <AL/alc.h>
+
+#ifdef HAVE_ALEXT_H
+#include <AL/alext.h>
+#endif
+
+#ifdef HAVE_EFX_H
+#include <AL/efx.h>
+#endif
+
+#ifdef HAVE_EFX_PRESETS_H
+#include <AL/efx-presets.h>
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // AUDIO_AL_H
+

--- a/src/audio/audio_fx.cpp
+++ b/src/audio/audio_fx.cpp
@@ -1,22 +1,9 @@
 
 #include "../config-opentomb.h"
 
-extern "C" {
-#include <al.h>
-#include <alc.h>
-#ifdef HAVE_ALEXT_H
-#include <alext.h>
-#endif
-#ifdef HAVE_EFX_H
-#include <efx.h>
-#endif
-#ifdef HAVE_EFX_PRESETS_H
-#include <efx-presets.h>
-#endif
-}
-
 #include <string.h>
 
+#include "audio_al.h"
 #include "audio.h"
 #include "audio_fx.h"
 

--- a/src/audio/audio_stream.cpp
+++ b/src/audio/audio_stream.cpp
@@ -6,11 +6,7 @@
 
 #include "../config-opentomb.h"
 
-extern "C" {
-#include <al.h>
-#include <alc.h>
-}
-
+#include "audio_al.h"
 #include "audio.h"
 #include "audio_stream.h"
 

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -12,10 +12,9 @@ extern "C" {
 #include <lua.h>
 #include <lualib.h>
 #include <lauxlib.h>
-#include <al.h>
-#include <alc.h>
 }
 
+#include "audio/audio_al.h"
 #include "core/system.h"
 #include "core/gl_util.h"
 #include "core/gl_font.h"

--- a/src/script/script_audio.cpp
+++ b/src/script/script_audio.cpp
@@ -7,8 +7,6 @@ extern "C" {
 #include <lua.h>
 #include <lualib.h>
 #include <lauxlib.h>
-#include <al.h>
-#include <alc.h>
 }
 
 #include "script.h"
@@ -17,6 +15,7 @@ extern "C" {
 #include "../core/gl_text.h"
 #include "../core/console.h"
 #include "../audio/audio.h"
+#include "../audio/audio_al.h"
 
 #include "../gameflow.h"
 #include "../engine.h"


### PR DESCRIPTION
I tried to compile OpenTomb with mingw-w64 under CYGWIN.
During this process I had got an error because it could not find OpenAL files.
This happened because in CYGWIN the path to the compiler does not match only to the compiler name, but it also includes an extra "/sys-root/mingw".
I did a fix into Toolchain-cross-mingw32-linux.cmake by declaring two different constants, one for the toolchain name prefix and one for the toolchain path prefix.
In this commit, I left previous situation and I kept commented the fix to CYGWIN. To get it working with this enviroment, the proper macro needs to be uncommented, in a similar manner it had to be done with the compiler name.
However, I would like to suggest to change the inclusion of openal files from:

#include <al.h>

to:

#include <AL/al.h>

by using the same convention tipically used with OpenGL, for example.
For this purpose I added src/audio/audio_al.h, that it is included in the various source files for simplify a bit. After that, the extra line in the configuration file for mingw cross compilation for adding a search path to the openal include files become useless, so it has been removed.

Sincerely.

PS: I do not own the games, so I tried to run the demos but I could not. Is it a known limitation/bug or I have to follow a particular procedure?