### PR TITLE
Fix inverted swimming gamepad controls while underwater (#378)

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -547,7 +547,7 @@ void Game_ApplyControls(struct entity_s *ent)
 
         if( (control_mapper.use_joy == 1) && (control_mapper.joy_move_y != 0 ) )
         {
-            ent->character->cmd.rot[1] = (control_mapper.joy_move_y > 0) ? (1) : (-1);
+            ent->character->cmd.rot[1] = (control_mapper.joy_move_y > 0) ? (-1) : (1);
         }
         else
         {


### PR DESCRIPTION
A very easy, self explanatory fix for #378. 

I did a quick search and `ent->character->cmd.rot[1]`seems to be used only for movement underwater, so I can't foresee any issues caused by this change elsewhere.