### PR TITLE
Fix Build Status in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-[![Build Status](https://travis-ci.org/opentomb/OpenTomb.svg?branch=master)]
-(https://travis-ci.org/opentomb/OpenTomb)
+[![Build Status](https://travis-ci.org/opentomb/OpenTomb.svg?branch=master)](https://travis-ci.org/opentomb/OpenTomb)
 
 OpenTomb — an open-source Tomb Raider 1-5 engine remake
 -------------------------------------------------------


### PR DESCRIPTION
Looks like splitting the Build status line breaks the link. Not sure why I didn't pick this up before, sorry. 

This breaks the 80 char line limit, but I don't see any other way around it.