### PR TITLE
Fix compilation on MSVC

### DIFF
--- a/src/fmv/internal/common.h
+++ b/src/fmv/internal/common.h
@@ -529,7 +529,7 @@ static inline int av_parity_c(uint32_t v)
 
 static inline int av_log2(uint32_t value)
 {
-#if 0
+#ifndef __GNUC__
     int ret = 0;
     for(; value; value >>= 1, ++ret);
     return ret ? ret - 1 : ret;


### PR DESCRIPTION
MSVC does not provide __builtin_clz intrinsic, but hopefully a portable implementation is available in the "#if 0" and it could be used in these circumstances,