### PR TITLE
Build fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,6 +204,11 @@ set(OPENTOMB_SRCS
     src/world.h
 )
 
+# Disable warnings when using unsafe functions
+if(WIN32)
+    add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+endif()
+
 if(MINGW AND CMAKE_CROSSCOMPILING)
     # Cross compiling on Linux with the MinGW toolchain.
     message(STATUS "MinGW Cross-Compilation")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,29 @@ project(OpenTomb)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 
+option(FORCE_SYSTEM_FREETYPE "Use system-provided FreeType instead of internal library." OFF)
+
+# Detect system FreeType
+
+if (FORCE_SYSTEM_FREETYPE)
+    find_package(freetype QUIET)
+    if (NOT FREETYPE_FOUND)
+        message(WARNING "FreeType not found. Enabling internal FreeType support.")
+        set(OPENTOMB_INTERNAL_FREETYPE ON)
+    else()
+        set(OPENTOMB_INTERNAL_FREETYPE OFF)
+    endif ()
+else ()
+    set(OPENTOMB_INTERNAL_FREETYPE ON)
+endif ()
+
+if (OPENTOMB_INTERNAL_FREETYPE)
+    add_subdirectory(extern/freetype2)
+    set(FREETYPE_INCLUDE_DIRS "")
+    set(FREETYPE_LIBRARIES freetype2)
+endif ()
+
 add_subdirectory(extern/bullet)
-add_subdirectory(extern/freetype2)
 add_subdirectory(extern/lua)
 
 set(OPENTOMB_SRCS
@@ -221,6 +242,7 @@ set_target_properties(${PROJECT_NAME} PROPERTIES C_STANDARD 99 CXX_STANDARD 11)
 
 target_include_directories(
     ${PROJECT_NAME} PRIVATE
+    ${FREETYPE_INCLUDE_DIRS}
     ${PNG_INCLUDE_DIRS}
     ${ZLIB_INCLUDE_DIRS}
     ${SDL2_INCLUDE_DIR}
@@ -231,7 +253,7 @@ target_include_directories(
 target_link_libraries(
     ${PROJECT_NAME}
     bullet
-    freetype2
+    ${FREETYPE_LIBRARIES}
     lua5.3
     ${PNG_LIBRARIES}
     ${OPENAL_LIBRARY}

--- a/src/core/gl_font.c
+++ b/src/core/gl_font.c
@@ -11,9 +11,9 @@
 #include <math.h>
 
 #include <ft2build.h>
-#include <freetype.h>
-#include <ftglyph.h>
-#include <ftmodapi.h>
+#include FT_FREETYPE_H
+#include FT_GLYPH_H
+#include FT_MODULE_H
 
 #include "utf8_32.h"
 #include "gl_font.h"


### PR DESCRIPTION
These are some of the fixes that I made to OpenTomb when I tried to compile it on MSVC.
See also issue #504.

- I added an option to CMakeList.txt for selecting between system provided FreeType and the other one. By default, if no options are specified, it uses the one included in the main sources, like now. When cmake is called with "-DFORCE_SYSTEM_FREETYPE=on", then it tries to search for a local copy. If it is not found, or if the option is not specified, the interal copy will be used.

- Fixed conflicts of include files between the system provided FreeType and the internal copy.

- Hide warning C4996, which is emitted when an "unsafe" function is used on MSVC.

I tried to do the first fix also for Bullet and LUA, but I have not a system provided copy of Bullet even on CYGWIN (so I could not test it) and it fails with LUA ver 5.2: it compiled fine but it gave errors at runtime, so I left both of them out of these patches.

Sincerely.
