### PR TITLE
pthread_t should not be used as 'int' type

### DIFF
--- a/src/fmv/stream_codec.h
+++ b/src/fmv/stream_codec.h
@@ -31,6 +31,7 @@ extern "C" {
 typedef struct stream_codec_s
 {
     struct tiny_codec_s      codec;
+    int                      is_thread_run;
     pthread_t                thread;
     pthread_mutex_t          timer_mutex;
     pthread_mutex_t          video_buffer_mutex;


### PR DESCRIPTION
With reference to issue #504, pthread_t is an opaque object and it is better to not handle it like an 'int' type. Actually, it rises an error with the pthread implementation in VS 2017. Attached patch fixes this thing.