### PR TITLE
Add selection of system LUA and BULLET libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,8 @@ project(OpenTomb)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 
 option(FORCE_SYSTEM_FREETYPE "Use system-provided FreeType instead of internal library." OFF)
+option(FORCE_SYSTEM_LUA      "Use system-provided LUA 5.3+ instead of internal library." OFF)
+option(FORCE_SYSTEM_BULLET   "Use system-provided BULLET instead of internal library."   OFF)
 
 # Detect system FreeType
 
@@ -27,12 +29,55 @@ endif ()
 
 if (OPENTOMB_INTERNAL_FREETYPE)
     add_subdirectory(extern/freetype2)
-    set(FREETYPE_INCLUDE_DIRS "")
+    set(FREETYPE_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/extern/freetype2")
     set(FREETYPE_LIBRARIES freetype2)
 endif ()
 
-add_subdirectory(extern/bullet)
-add_subdirectory(extern/lua)
+# Detect system LUA
+
+if (FORCE_SYSTEM_LUA)
+    find_package(lua QUIET)
+    if (NOT LUA_FOUND)
+        message(WARNING "LUA not found. Enabling internal LUA support.")
+        set(OPENTOMB_INTERNAL_LUA ON)
+    else ()
+        # Set minimal version
+        set (LUA_MIN_VERSION 5.3)
+        if (LUA_VERSION_STRING VERSION_EQUAL LUA_MIN_VERSION OR LUA_VERSION_STRING VERSION_GREATER LUA_MIN_VERSION)
+            set(OPENTOMB_INTERNAL_LUA OFF)
+        else ()
+            message(WARNING "Incorrect LUA version found. Enabling internal LUA support.")
+        endif ()
+    endif ()
+else ()
+    set(OPENTOMB_INTERNAL_LUA ON)
+endif ()
+
+if (OPENTOMB_INTERNAL_LUA)
+    add_subdirectory(extern/lua)
+    set(LUA_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/extern/lua")
+    set(LUA_LIBRARIES lua5.3)
+endif ()
+
+# Detect system BULLET
+
+if (FORCE_SYSTEM_BULLET)
+    find_package(bullet QUIET)
+    if (NOT BULLET_FOUND)
+        message(WARNING "BULLET not found. Enabling internal BULLET support.")
+        set(OPENTOMB_INTERNAL_BULLET ON)
+    else()
+        set(OPENTOMB_INTERNAL_BULLET OFF)
+    endif ()
+else ()
+    set(OPENTOMB_INTERNAL_BULLET ON)
+endif ()
+
+if (OPENTOMB_INTERNAL_BULLET)
+    add_subdirectory(extern/bullet)
+    set(BULLET_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/extern/bullet")
+    set(BULLET_LIBRARIES bullet)
+endif ()
 
 set(OPENTOMB_SRCS
     src/core/avl.c
@@ -248,6 +293,8 @@ set_target_properties(${PROJECT_NAME} PROPERTIES C_STANDARD 99 CXX_STANDARD 11)
 target_include_directories(
     ${PROJECT_NAME} PRIVATE
     ${FREETYPE_INCLUDE_DIRS}
+    ${LUA_INCLUDE_DIR}
+    ${BULLET_INCLUDE_DIRS}
     ${PNG_INCLUDE_DIRS}
     ${ZLIB_INCLUDE_DIRS}
     ${SDL2_INCLUDE_DIR}
@@ -257,9 +304,9 @@ target_include_directories(
 
 target_link_libraries(
     ${PROJECT_NAME}
-    bullet
     ${FREETYPE_LIBRARIES}
-    lua5.3
+    ${LUA_LIBRARIES}
+    ${BULLET_LIBRARIES}
     ${PNG_LIBRARIES}
     ${OPENAL_LIBRARY}
     ${SDL2_LIBRARY}

--- a/src/controls.cpp
+++ b/src/controls.cpp
@@ -6,12 +6,7 @@
 #include <SDL2/SDL_scancode.h>
 #include <SDL2/SDL_events.h>
 
-extern "C" {
-#include <lua.h>
-#include <lualib.h>
-#include <lauxlib.h>
-}
-
+#include "core/lua.h"
 #include "core/system.h"
 #include "core/console.h"
 #include "core/vmath.h"

--- a/src/core/console.c
+++ b/src/core/console.c
@@ -1,14 +1,13 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <memory.h>
+
 #include <SDL2/SDL_platform.h>
 #include <SDL2/SDL_opengl.h>
 #include <SDL2/SDL_keycode.h>
 
-#include <lua.h>
-#include <lualib.h>
-#include <lauxlib.h>
-#include <memory.h>
+#include "../core/lua.h"
 
 #include "utf8_32.h"
 #include "gl_font.h"

--- a/src/core/lua.h
+++ b/src/core/lua.h
@@ -1,0 +1,16 @@
+#ifndef __OT_CORE_LUA_H
+#define __OT_CORE_LUA_H
+
+#ifdef	__cplusplus
+extern "C" {
+#endif
+
+#include "lua.h"
+#include "lualib.h"
+#include "lauxlib.h"
+
+#ifdef	__cplusplus
+}
+#endif
+
+#endif /* __OT_CORE_LUA_H */

--- a/src/core/system.c
+++ b/src/core/system.c
@@ -12,9 +12,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <lua.h>
-#include <lualib.h>
-#include <lauxlib.h>
+#include "../core/lua.h"
 
 #include "system.h"
 #include "utf8_32.h"

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -8,12 +8,8 @@
 #include <ctype.h>
 #include <time.h>
 
-extern "C" {
-#include <lua.h>
-#include <lualib.h>
-#include <lauxlib.h>
-}
 
+#include "core/lua.h"
 #include "core/system.h"
 #include "core/gl_util.h"
 #include "core/gl_font.h"

--- a/src/entity.cpp
+++ b/src/entity.cpp
@@ -1,12 +1,7 @@
 #include <stdlib.h>
 #include <math.h>
 
-extern "C" {
-#include <lua.h>
-#include <lualib.h>
-#include <lauxlib.h>
-}
-
+#include "core/lua.h"
 #include "core/console.h"
 #include "core/vmath.h"
 #include "core/obb.h"

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2,12 +2,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-extern "C" {
-#include <lua.h>
-#include <lualib.h>
-#include <lauxlib.h>
-}
-
+#include "core/lua.h"
 #include "core/system.h"
 #include "core/console.h"
 #include "core/vmath.h"

--- a/src/gameflow.cpp
+++ b/src/gameflow.cpp
@@ -1,9 +1,4 @@
-extern "C" {
-#include <lua.h>
-#include <lualib.h>
-#include <lauxlib.h>
-}
-
+#include "core/lua.h"
 #include "core/gl_text.h"
 #include "core/console.h"
 #include "script/script.h"

--- a/src/physics/hair.cpp
+++ b/src/physics/hair.cpp
@@ -1,11 +1,7 @@
 
 #include <stdlib.h>
-extern "C" {
-#include <lua.h>
-#include <lualib.h>
-#include <lauxlib.h>
-}
 
+#include "../core/lua.h"
 #include "hair.h"
 
 struct hair_setup_s *Hair_GetSetup(struct lua_State *lua, int stack_pos)

--- a/src/physics/ragdoll.cpp
+++ b/src/physics/ragdoll.cpp
@@ -1,12 +1,8 @@
 
 #include <stdlib.h>
 #include <string.h>
-extern "C" {
-#include <lua.h>
-#include <lualib.h>
-#include <lauxlib.h>
-}
 
+#include "../core/lua.h"
 #include "../core/vmath.h"
 #include "ragdoll.h"
 #include "../mesh.h"

--- a/src/resource.cpp
+++ b/src/resource.cpp
@@ -6,12 +6,7 @@
 #include <stdlib.h>
 #include <SDL2/SDL.h>
 
-extern "C" {
-#include <lua.h>
-#include <lualib.h>
-#include <lauxlib.h>
-}
-
+#include "core/lua.h"
 #include "core/system.h"
 #include "core/vmath.h"
 #include "core/gl_util.h"

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -3,11 +3,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-extern "C" {
-#include <lua.h>
-#include <lualib.h>
-#include <lauxlib.h>
-}
+#include "../core/lua.h"
 
 #include "script.h"
 #include "../core/system.h"

--- a/src/script/script_audio.cpp
+++ b/src/script/script_audio.cpp
@@ -3,11 +3,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-extern "C" {
-#include <lua.h>
-#include <lualib.h>
-#include <lauxlib.h>
-}
+#include "../core/lua.h"
 
 #include "script.h"
 

--- a/src/script/script_character.cpp
+++ b/src/script/script_character.cpp
@@ -3,11 +3,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-extern "C" {
-#include <lua.h>
-#include <lualib.h>
-#include <lauxlib.h>
-}
+#include "../core/lua.h"
 
 #include "script.h"
 

--- a/src/script/script_entity.cpp
+++ b/src/script/script_entity.cpp
@@ -3,11 +3,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-extern "C" {
-#include <lua.h>
-#include <lualib.h>
-#include <lauxlib.h>
-}
+#include "../core/lua.h"
 
 #include "script.h"
 

--- a/src/script/script_skeletal_model.cpp
+++ b/src/script/script_skeletal_model.cpp
@@ -3,11 +3,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-extern "C" {
-#include <lua.h>
-#include <lualib.h>
-#include <lauxlib.h>
-}
+#include "../core/lua.h"
 
 #include "script.h"
 

--- a/src/script/script_world.cpp
+++ b/src/script/script_world.cpp
@@ -3,11 +3,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-extern "C" {
-#include <lua.h>
-#include <lualib.h>
-#include <lauxlib.h>
-}
+#include "../core/lua.h"
 
 #include "script.h"
 

--- a/src/trigger.cpp
+++ b/src/trigger.cpp
@@ -4,12 +4,7 @@
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_rwops.h>
 
-extern "C" {
-#include <lua.h>
-#include <lualib.h>
-#include <lauxlib.h>
-}
-
+#include "core/lua.h"
 #include "core/system.h"
 #include "core/console.h"
 #include "core/vmath.h"

--- a/src/world.cpp
+++ b/src/world.cpp
@@ -4,12 +4,7 @@
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_rwops.h>
 
-extern "C" {
-#include <lua.h>
-#include <lualib.h>
-#include <lauxlib.h>
-}
-
+#include "core/lua.h"
 #include "core/avl.h"
 #include "core/gl_util.h"
 #include "core/console.h"


### PR DESCRIPTION
This patch includes support for selecting system provided LUA 5.3 (and newer) and BULLET, in a similar manner it had been done for FreeType.

* Added two new options, FORCE_SYSTEM_LUA and FORCE_SYSTEM_BULLET. By default, they are OFF so the internal copies or the libraries will be used without parameters. LUA is accepted only if version 5.3 or newer is found.

* Added a new file,  src/core/lua.h, used for including LUA stuff.

* Inside src/core/lua.h, include directive has been changed from:
`#include <lua.h>`
to:
` #include "lua.h"`
as it has been written in the CMAKE documentation:
https://cmake.org/cmake/help/v3.0/module/FindLua.html

Tested with MINGW-W64 cross compiler: LUA 5.2 is rejected, BULLET is not found.
Tested with MSVC Community 2017: LUA 5.3 and BULLET are found and accepted.