### PR TITLE
Made CMake selection of FreeType library work on Linux.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ option(FORCE_SYSTEM_FREETYPE "Use system-provided FreeType instead of internal l
 # Detect system FreeType
 
 if (FORCE_SYSTEM_FREETYPE)
-    find_package(freetype QUIET)
+    find_package(Freetype QUIET)
     if (NOT FREETYPE_FOUND)
         message(WARNING "FreeType not found. Enabling internal FreeType support.")
         set(OPENTOMB_INTERNAL_FREETYPE ON)


### PR DESCRIPTION
Hi,
Using system-provided FreeType library is not working on Linux due to case sensitivity :
```
ar@ar-i7:~/Documents/OpenTomb/build$ cmake -DFORCE_SYSTEM_FREETYPE=ON ..
-- The C compiler identification is GNU 7.2.0
-- The CXX compiler identification is GNU 7.2.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
CMake Warning at CMakeLists.txt:17 (find_package):
  By not providing "Findfreetype.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "freetype",
  but CMake did not find one.

  Could not find a package configuration file provided by "freetype" with any
  of the following names:

    freetypeConfig.cmake
    freetype-config.cmake

  Add the installation prefix of "freetype" to CMAKE_PREFIX_PATH or set
  "freetype_DIR" to a directory containing one of the above files.  If
  "freetype" provides a separate development package or SDK, be sure it has
  been installed.


CMake Warning at CMakeLists.txt:19 (message):
  FreeType not found.  Enabling internal FreeType support.


-- Found ZLIB: /usr/lib/x86_64-linux-gnu/libz.so (found version "1.2.11") 
-- Found OpenAL: /usr/lib/x86_64-linux-gnu/libopenal.so  
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Looking for pthread_create
-- Looking for pthread_create - not found
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE  
-- Found SDL2: /usr/lib/x86_64-linux-gnu/libSDL2main.a;/usr/lib/x86_64-linux-gnu/libSDL2.so;-lpthread  
-- Found PNG: /usr/lib/x86_64-linux-gnu/libpng.so (found version "1.6.34") 
-- Looking for include file alext.h
-- Looking for include file alext.h - found
-- Looking for include file efx.h
-- Looking for include file efx.h - found
-- Looking for include file efx-presets.h
-- Looking for include file efx-presets.h - found
-- Configuring done
-- Generating done
-- Build files have been written to: /home/ar/Documents/OpenTomb/build
```
The CMake module searching for the package is made of Find *package name* .cmake, and it is called FindFreetype.cmake on Linux.