### PR TITLE
Update Windows Compiler Compatibility

### DIFF
--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -1,16 +1,28 @@
-
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_audio.h>
 
 #include <math.h>
 
-#include "../config-opentomb.h"
+#ifdef __GNUC__
+#   include "../config-opentomb.h"
+#else
+// no cmake to convert it.
+#   include "../config-default/config-opentomb.h"
+#endif
 
 extern "C" {
-#include <al.h>
-#include <alc.h>
-#ifdef HAVE_ALEXT_H
-#include <alext.h>
+#ifdef __GNUC__
+#   include <al.h>
+#   include <alc.h>
+#   ifdef HAVE_ALEXT_H
+#       include <alext.h>
+#   endif
+#else
+#   include <AL/al.h>
+#   include <AL/alc.h>
+#   ifdef HAVE_ALEXT_H
+#       include <AL/alext.h>
+#   endif
 #endif
 }
 

--- a/src/audio/audio_fx.cpp
+++ b/src/audio/audio_fx.cpp
@@ -1,17 +1,35 @@
-
-#include "../config-opentomb.h"
+#ifdef __GNUC__
+#   include "../config-opentomb.h"
+#else
+// no cmake to convert it.
+#   include "../config-default/config-opentomb.h"
+#endif
 
 extern "C" {
-#include <al.h>
-#include <alc.h>
-#ifdef HAVE_ALEXT_H
-#include <alext.h>
-#endif
-#ifdef HAVE_EFX_H
-#include <efx.h>
-#endif
-#ifdef HAVE_EFX_PRESETS_H
-#include <efx-presets.h>
+#ifdef __GNUC__
+#   include <al.h>
+#   include <alc.h>
+#   ifdef HAVE_ALEXT_H
+#       include <alext.h>
+#   endif
+#   ifdef HAVE_EFX_H
+#       include <efx.h>
+#   endif
+#   ifdef HAVE_EFX_PRESETS_H
+#       include <efx-presets.h>
+#   endif
+#else
+#   include <AL/al.h>
+#   include <AL/alc.h>
+#   ifdef HAVE_ALEXT_H
+#       include <AL/alext.h>
+#   endif
+#   ifdef HAVE_EFX_H
+#       include <AL/efx.h>
+#   endif
+#   ifdef HAVE_EFX_PRESETS_H
+#       include <AL/efx-presets.h>
+#   endif
 #endif
 }
 

--- a/src/core/base_types.h
+++ b/src/core/base_types.h
@@ -62,7 +62,12 @@ typedef struct engine_container_s
 
 typedef struct engine_transform_s
 {
+#ifdef __GNUC__
     float                        M4x4[16] __attribute__((packed, aligned(16))); // GL transformation matrix
+#else
+    float                        M4x4[16]; // GL transformation matrix
+#endif
+
     float                        scaling[3];         // entity scaling
     float                        angles[3];
 } engine_transform_t, *engine_transform_p;

--- a/src/core/gl_text.c
+++ b/src/core/gl_text.c
@@ -124,7 +124,7 @@ void GLText_RenderStringLine(gl_text_line_p l)
     if(l->show && (gl_font = GLText_GetFont(l->font_id)) && (style = GLText_GetFontStyle(l->style_id)))
     {
         GLfloat real_x = 0.0f, real_y = 0.0f;
-        int32_t x0, y0, x1, y1;
+        int32_t x0 = 0, y0 = 0, x1, y1;
         GLfloat shadow_color[4];
         int32_t w_pt = (l->line_width * 64.0f + 0.5f);
         GLfloat ascender = glf_get_ascender(gl_font) / 64.0f;

--- a/src/core/system.c
+++ b/src/core/system.c
@@ -5,7 +5,12 @@
 #include <SDL2/SDL_video.h>
 #include <SDL2/SDL_audio.h>
 #include <sys/stat.h>
-#include <sys/time.h>
+#ifdef __GNUC__
+#   include <sys/time.h>
+#else
+#   include "timer.h"
+#endif
+
 #include <time.h>
 #include <dirent.h>
 #include <stdio.h>
@@ -263,7 +268,11 @@ int64_t Sys_MicroSecTime(int64_t sec_offset)
 {
     int64_t ret = 0;
     struct timeval tp;
-    if(0 == gettimeofday(&tp, NULL))
+#ifdef __GNUC__
+    if (0 == gettimeofday(&tp, NULL))
+#else
+    if (0 == _gettimeofday(&tp, NULL))
+#endif
     {
         ret = tp.tv_sec - sec_offset;
         ret *= 1e6;

--- a/src/fmv/stream_codec.c
+++ b/src/fmv/stream_codec.c
@@ -1,14 +1,14 @@
-
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
-
 #include <SDL2/SDL.h>
+
 #ifndef _POSIX_SOURCE
 #define __USE_POSIX199309  (1)   // make posix GCC workable
 #define __USE_XOPEN2K
 #endif
+
 #include <pthread.h>
 #ifdef _TIMESPEC_DEFINED         // make MinGW workable
 #include <pthread_time.h>
@@ -16,6 +16,11 @@
 
 #include "tiny_codec.h"
 #include "stream_codec.h"
+
+#ifndef __GNUC__
+#   define CLOCK_REALTIME 0
+#   include "timer.h"
+#endif
 
 void stream_codec_init(stream_codec_p s)
 {
@@ -83,7 +88,11 @@ static void *stream_codec_thread_func(void *data)
         struct timespec vid_time;
         int can_continue = 1;
 
+#ifdef __GNUC__
         clock_gettime(CLOCK_REALTIME, &time_start);
+#else
+        _clock_gettime(CLOCK_REALTIME, &time_start);
+#endif
 
         while(!s->stop && can_continue)
         {

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -555,7 +555,7 @@ bool Gui_LoadScreenAssignPic(const char* pic_name)
     size_t pic_len = strlen(pic_name);
     size_t base_len = strlen(Engine_GetBasePath());
     size_t buf_len = pic_len + base_len + 5;
-    char image_name_buf[buf_len];
+    char *image_name_buf = new char[buf_len];
     int image_format = 0;
 
     strncpy(image_name_buf, Engine_GetBasePath(), buf_len);

--- a/src/render/camera.h
+++ b/src/render/camera.h
@@ -66,9 +66,15 @@ typedef struct camera_state_s
 
 typedef struct camera_s
 {
+#ifdef __GNUC__
     GLfloat                     gl_view_mat[16] __attribute__((packed, aligned(16)));
     GLfloat                     gl_proj_mat[16] __attribute__((packed, aligned(16)));
     GLfloat                     gl_view_proj_mat[16] __attribute__((packed, aligned(16)));
+#else
+    GLfloat                     gl_view_mat[16];
+    GLfloat                     gl_proj_mat[16];
+    GLfloat                     gl_view_proj_mat[16];
+#endif
     engine_transform_s          transform;
     
     GLfloat                     clip_planes[16];        // frustum side clip planes

--- a/src/room.h
+++ b/src/room.h
@@ -222,8 +222,11 @@ typedef struct static_mesh_s
     float                       vbb_max[3];
     float                       cbb_min[3];                                     // collision bounding box
     float                       cbb_max[3];
-
-    float                       transform[16]   __attribute__((packed, aligned(16)));   // gl transformation matrix
+#ifdef __GNUC__
+    float                       transform[16] __attribute__((packed, aligned(16)));   // gl transformation matrix
+#else
+    float                       transform[16]; // GL transformation matrix
+#endif
     struct obb_s               *obb;
     struct engine_container_s  *self;
 
@@ -278,7 +281,11 @@ typedef struct room_s
     struct obb_s               *obb;
     float                       bb_min[3];                                      // effective room box, exclude portal sectors zones
     float                       bb_max[3];                                      //
+#ifdef __GNUC__
     float                       transform[16] __attribute__((packed, aligned(16))); // GL transformation matrix
+#else
+    float                       transform[16]; // GL transformation matrix
+#endif
     uint32_t                    sectors_count;
     uint16_t                    sectors_x;
     uint16_t                    sectors_y;

--- a/src/timer.cpp
+++ b/src/timer.cpp
@@ -6,53 +6,53 @@ static LARGE_INTEGER g_counts_per_sec;
 
 struct timespec
 {
-	time_t tv_sec;
-	long tv_nsec;
+    time_t tv_sec;
+    long tv_nsec;
 };
 
 int _clock_gettime(int dummy, struct timespec *ct)
 {
-	LARGE_INTEGER count;
-	if (g_first_time)
-	{
-		g_first_time = 0;
-		if (0 == QueryPerformanceFrequency(&g_counts_per_sec))
-		{
-			g_counts_per_sec.QuadPart = 0;
-		}
-	}
+    LARGE_INTEGER count;
+    if (g_first_time)
+    {
+        g_first_time = 0;
+        if (0 == QueryPerformanceFrequency(&g_counts_per_sec))
+        {
+            g_counts_per_sec.QuadPart = 0;
+        }
+    }
 
-	if ((NULL == ct) || (g_counts_per_sec.QuadPart <= 0) ||
-		(0 == QueryPerformanceCounter(&count)))
-	{
-		return -1;
-	}
+    if ((NULL == ct) || (g_counts_per_sec.QuadPart <= 0) ||
+        (0 == QueryPerformanceCounter(&count)))
+    {
+        return -1;
+    }
 
-	ct->tv_sec = count.QuadPart / g_counts_per_sec.QuadPart;
-	ct->tv_nsec = ((count.QuadPart % g_counts_per_sec.QuadPart) * BILLION) / g_counts_per_sec.QuadPart;
-	return 0;
+    ct->tv_sec = count.QuadPart / g_counts_per_sec.QuadPart;
+    ct->tv_nsec = ((count.QuadPart % g_counts_per_sec.QuadPart) * BILLION) / g_counts_per_sec.QuadPart;
+    return 0;
 }
 
 int _gettimeofday(struct timeval *p, void *tz)
 {
-	ULARGE_INTEGER ul; // As specified on MSDN.
-	FILETIME ft;
+    ULARGE_INTEGER ul; // As specified on MSDN.
+    FILETIME ft;
 
-	// Returns a 64-bit value representing the number of
-	// 100-nanosecond intervals since January 1, 1601 (UTC).
-	GetSystemTimeAsFileTime(&ft);
+    // Returns a 64-bit value representing the number of
+    // 100-nanosecond intervals since January 1, 1601 (UTC).
+    GetSystemTimeAsFileTime(&ft);
 
-	// Fill ULARGE_INTEGER low and high parts.
-	ul.LowPart = ft.dwLowDateTime;
-	ul.HighPart = ft.dwHighDateTime;
-	// Convert to microseconds.
-	ul.QuadPart /= 10ULL;
-	// Remove Windows to UNIX Epoch delta.
-	ul.QuadPart -= 11644473600000000ULL;
-	// Modulo to retrieve the microseconds.
-	p->tv_usec = (long) (ul.QuadPart % 1000000LL);
-	// Divide to retrieve the seconds.
-	p->tv_sec = (long) (ul.QuadPart / 1000000LL);
+    // Fill ULARGE_INTEGER low and high parts.
+    ul.LowPart = ft.dwLowDateTime;
+    ul.HighPart = ft.dwHighDateTime;
+    // Convert to microseconds.
+    ul.QuadPart /= 10ULL;
+    // Remove Windows to UNIX Epoch delta.
+    ul.QuadPart -= 11644473600000000ULL;
+    // Modulo to retrieve the microseconds.
+    p->tv_usec = (long) (ul.QuadPart % 1000000LL);
+    // Divide to retrieve the seconds.
+    p->tv_sec = (long) (ul.QuadPart / 1000000LL);
 
-	return 0;
+    return 0;
 }

--- a/src/timer.cpp
+++ b/src/timer.cpp
@@ -1,0 +1,58 @@
+#include "timer.h"
+#include <windows.h>
+
+static BOOL g_first_time = 1;
+static LARGE_INTEGER g_counts_per_sec;
+
+struct timespec
+{
+	time_t tv_sec;
+	long tv_nsec;
+};
+
+int _clock_gettime(int dummy, struct timespec *ct)
+{
+	LARGE_INTEGER count;
+	if (g_first_time)
+	{
+		g_first_time = 0;
+		if (0 == QueryPerformanceFrequency(&g_counts_per_sec))
+		{
+			g_counts_per_sec.QuadPart = 0;
+		}
+	}
+
+	if ((NULL == ct) || (g_counts_per_sec.QuadPart <= 0) ||
+		(0 == QueryPerformanceCounter(&count)))
+	{
+		return -1;
+	}
+
+	ct->tv_sec = count.QuadPart / g_counts_per_sec.QuadPart;
+	ct->tv_nsec = ((count.QuadPart % g_counts_per_sec.QuadPart) * BILLION) / g_counts_per_sec.QuadPart;
+	return 0;
+}
+
+int _gettimeofday(struct timeval *p, void *tz)
+{
+	ULARGE_INTEGER ul; // As specified on MSDN.
+	FILETIME ft;
+
+	// Returns a 64-bit value representing the number of
+	// 100-nanosecond intervals since January 1, 1601 (UTC).
+	GetSystemTimeAsFileTime(&ft);
+
+	// Fill ULARGE_INTEGER low and high parts.
+	ul.LowPart = ft.dwLowDateTime;
+	ul.HighPart = ft.dwHighDateTime;
+	// Convert to microseconds.
+	ul.QuadPart /= 10ULL;
+	// Remove Windows to UNIX Epoch delta.
+	ul.QuadPart -= 11644473600000000ULL;
+	// Modulo to retrieve the microseconds.
+	p->tv_usec = (long) (ul.QuadPart % 1000000LL);
+	// Divide to retrieve the seconds.
+	p->tv_sec = (long) (ul.QuadPart / 1000000LL);
+
+	return 0;
+}

--- a/src/timer.h
+++ b/src/timer.h
@@ -1,0 +1,15 @@
+#ifndef TIMER_H
+#define TIMER_H
+    
+    #define BILLION (1E9)
+
+	#ifdef	__cplusplus
+	extern "C" {
+	#endif
+		int _clock_gettime(int dummy, struct timespec *ct);
+		int _gettimeofday(struct timeval *p, void *tz);
+	#ifdef	__cplusplus
+	}
+	#endif
+	
+#endif

--- a/src/timer.h
+++ b/src/timer.h
@@ -3,13 +3,15 @@
     
     #define BILLION (1E9)
 
-	#ifdef	__cplusplus
-	extern "C" {
-	#endif
-		int _clock_gettime(int dummy, struct timespec *ct);
-		int _gettimeofday(struct timeval *p, void *tz);
-	#ifdef	__cplusplus
-	}
-	#endif
+    #ifdef    __cplusplus
+    extern "C" {
+    #endif
 	
+    int _clock_gettime(int dummy, struct timespec *ct);
+    int _gettimeofday(struct timeval *p, void *tz);
+	
+    #ifdef    __cplusplus
+    }
+    #endif
+    
 #endif


### PR DESCRIPTION
the attributes(packed, aligned) not exist on windows compiler (stdc++17),
because, if bullet not crash, windows compiler will align the variable correctly.
i added some fix like config-opentomb for no cmake user, lua path "AL/".
and added new cpp: "timer.cpp" that fix clock_gettime() and gettimeofday (and fix CLOCK_REALTIME too),
and fixed "char image_name_buf[]" not compatible with c++17 (maybe need check about it).